### PR TITLE
Implement status tracking and API endpoints

### DIFF
--- a/site/models.py
+++ b/site/models.py
@@ -9,6 +9,8 @@ class Solicitacao(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     obra = db.Column(db.String(100), nullable=False)
     data = db.Column(db.DateTime, default=datetime.utcnow)
+    status = db.Column(db.String(20), default='pendente')
+    faltantes = db.Column(db.Text)
     itens = db.relationship('Item', backref='solicitacao', cascade='all, delete-orphan')
 
 class Item(db.Model):

--- a/site/projetista/templates/index.html
+++ b/site/projetista/templates/index.html
@@ -1,5 +1,26 @@
 {% extends 'base.html' %}
 {% block body %}
   <h1>Status do pedido</h1>
-  <p>Use o menu acima para criar ou ver solicitações de materiais.</p>
+  <table class="table">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Obra</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for sol in solicitacoes %}
+        <tr>
+          <td>{{ sol.id }}</td>
+          <td>{{ sol.obra }}</td>
+          <td>{{ sol.status }}</td>
+        </tr>
+      {% else %}
+        <tr>
+          <td colspan="3" class="text-muted">Nenhuma solicitação registrada.</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `status` and `faltantes` fields to `Solicitacao`
- show solicitacao status on home page
- extend API to return status info
- add endpoints to mark solicitacao as going to compras or aprovada

## Testing
- `python -m py_compile site/app.py site/models.py site/projetista/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68839c5636ec832fb75b49238ea00c6a