### PR TITLE
Filter duplicate obras on status page

### DIFF
--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -15,7 +15,16 @@ bp = Blueprint('projetista', __name__)
 @bp.route('/')
 def index():
     consulta = Solicitacao.query.order_by(Solicitacao.data.desc()).all()
-    return render_template('index.html', solicitacoes=consulta)
+
+    # Mantém apenas a ocorrência mais recente de cada obra
+    unicas = []
+    vistas = set()
+    for sol in consulta:
+        if sol.obra not in vistas:
+            unicas.append(sol)
+            vistas.add(sol.obra)
+
+    return render_template('index.html', solicitacoes=unicas)
 
 @bp.route('/solicitacoes')
 def solicitacoes():


### PR DESCRIPTION
## Summary
- avoid repeated `obra` entries on the status page by selecting only the latest record for each `obra`

## Testing
- `python -m py_compile site/projetista/__init__.py`
- `pip install -q Flask Flask-SQLAlchemy openpyxl pytz` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6883b10e87fc832fb007db412742b6d2