### PR TITLE
Fix solicitation list after checklist

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/Solicitacao.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/Solicitacao.kt
@@ -14,5 +14,6 @@ data class Solicitacao(
     val obra: String,
     val data: String,
     val itens: List<Item>,
-    val status: String? = null
+    val status: String? = null,
+    val pendencias: String? = null
 )

--- a/AppEstoque/app/src/main/java/com/example/apestoque/fragments/SolicitacoesFragment.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/fragments/SolicitacoesFragment.kt
@@ -104,14 +104,16 @@ class SolicitacoesFragment : Fragment() {
                     NetworkModule.api.listarSolicitacoes()
                 }
 
-                if (lista.isEmpty()) {
+                val pendentes = lista.filter { it.status != "aprovado" && it.pendencias == null }
+
+                if (pendentes.isEmpty()) {
                     tvMensagem.text = "Nenhuma solicitação encontrada."
                     tvMensagem.visibility = View.VISIBLE
                     rvSolicitacoes.visibility = View.GONE
                     todasSolicitacoes = emptyList()
                 } else {
                     // Agrupa por obra e pega a última solicitação de cada obra
-                    val ultimasPorObra = lista
+                    val ultimasPorObra = pendentes
                         .groupBy { it.obra }
                         .mapNotNull { (_, group) -> group.maxByOrNull { it.id } }
                         .sortedByDescending { it.id }


### PR DESCRIPTION
## Summary
- include `pendencias` field when decoding `Solicitacao`
- show only unprocessed requests in the solicitation tab

## Testing
- `pytest -q`
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6883b341a060832facd0a55cdadbcb8c