### PR TITLE
Add login and filtering features

### DIFF
--- a/site/app.py
+++ b/site/app.py
@@ -1,8 +1,11 @@
 # app.py
 import os
 from flask import Flask
-from models import db
+from models import db, User
 from projetista import bp as projetista_bp
+from compras import bp as compras_bp
+from auth import bp as auth_bp
+from flask_login import LoginManager
 
 def create_app():
     app = Flask(__name__, template_folder="projetista/templates")
@@ -16,10 +19,26 @@ def create_app():
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
     db.init_app(app)
+
+    login_manager = LoginManager()
+    login_manager.login_view = 'auth.login'
+    login_manager.init_app(app)
+
+    @login_manager.user_loader
+    def load_user(user_id):
+        return User.query.get(int(user_id))
+
     app.register_blueprint(projetista_bp, url_prefix='/projetista')
+    app.register_blueprint(compras_bp, url_prefix='/compras')
+    app.register_blueprint(auth_bp)
 
     with app.app_context():
         db.create_all()
+        if not User.query.filter_by(username='admin').first():
+            admin = User(username='admin', role='admin')
+            admin.set_password('admin')
+            db.session.add(admin)
+            db.session.commit()
 
     return app
 

--- a/site/auth/__init__.py
+++ b/site/auth/__init__.py
@@ -1,0 +1,26 @@
+from flask import Blueprint, render_template, request, redirect, url_for, flash
+from flask_login import login_user, logout_user, login_required
+from models import User
+
+bp = Blueprint('auth', __name__, template_folder='templates')
+
+@bp.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form.get('username')
+        password = request.form.get('password')
+        user = User.query.filter_by(username=username).first()
+        if user and user.check_password(password):
+            login_user(user)
+            if user.role == 'admin':
+                return redirect(url_for('projetista.index'))
+            else:
+                return redirect(url_for('compras.index'))
+        flash('Credenciais inválidas', 'danger')
+    return render_template('login.html')
+
+@bp.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('auth.login'))

--- a/site/auth/templates/login.html
+++ b/site/auth/templates/login.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <title>Login</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+</head>
+<body class="bg-light d-flex justify-content-center align-items-center" style="height:100vh;">
+  <div class="card p-4 shadow" style="min-width:300px;">
+    <h1 class="h4 mb-3 text-center">Entrar</h1>
+    <form method="post">
+      <div class="form-floating mb-3">
+        <input type="text" class="form-control" id="username" name="username" placeholder="Usuário" required>
+        <label for="username">Usuário</label>
+      </div>
+      <div class="form-floating mb-3">
+        <input type="password" class="form-control" id="password" name="password" placeholder="Senha" required>
+        <label for="password">Senha</label>
+      </div>
+      <div class="d-grid">
+        <button type="submit" class="btn btn-primary">Entrar</button>
+      </div>
+    </form>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/site/compras/__init__.py
+++ b/site/compras/__init__.py
@@ -1,0 +1,11 @@
+from flask import Blueprint, render_template
+from flask_login import login_required
+from models import Solicitacao
+
+bp = Blueprint('compras', __name__, template_folder='../projetista/templates')
+
+@bp.route('/')
+@login_required
+def index():
+    solicitacoes = Solicitacao.query.order_by(Solicitacao.data.desc()).all()
+    return render_template('index.html', solicitacoes=solicitacoes)

--- a/site/models.py
+++ b/site/models.py
@@ -1,6 +1,8 @@
 # models.py
 from datetime import datetime
 from flask_sqlalchemy import SQLAlchemy
+from flask_login import UserMixin
+from werkzeug.security import generate_password_hash, check_password_hash
 
 db = SQLAlchemy()
 
@@ -20,3 +22,17 @@ class Item(db.Model):
     solicitacao_id = db.Column(db.Integer, db.ForeignKey('solicitacao.id'), nullable=False)
     referencia = db.Column(db.String(100), nullable=False)
     quantidade = db.Column(db.Integer, nullable=False)
+
+
+class User(UserMixin, db.Model):
+    __tablename__ = 'user'
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    role = db.Column(db.String(20), nullable=False)
+
+    def set_password(self, password: str) -> None:
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password: str) -> bool:
+        return check_password_hash(self.password_hash, password)

--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -1,6 +1,7 @@
 # projetista/__init__.py
 from flask import Blueprint, render_template, request, redirect, url_for, flash
 from models import db, Solicitacao, Item
+from flask_login import login_required, current_user
 import json
 from collections import defaultdict
 import io
@@ -13,6 +14,7 @@ from flask import jsonify
 bp = Blueprint('projetista', __name__)
 
 @bp.route('/')
+@login_required
 def index():
     consulta = Solicitacao.query.order_by(Solicitacao.data.desc()).all()
 
@@ -27,6 +29,7 @@ def index():
     return render_template('index.html', solicitacoes=unicas)
 
 @bp.route('/solicitacoes')
+@login_required
 def solicitacoes():
     consulta = Solicitacao.query.order_by(Solicitacao.data.asc()).all()
     tz = pytz.timezone('America/Sao_Paulo')
@@ -46,6 +49,7 @@ def solicitacoes():
 
 
 @bp.route('/solicitacao/nova', methods=['GET', 'POST'])
+@login_required
 def nova_solicitacao():
     if request.method == 'POST':
         obra = request.form['obra'].strip()
@@ -94,6 +98,7 @@ def nova_solicitacao():
 
 
 @bp.route('/comparador', methods=['GET', 'POST'])
+@login_required
 def comparador():
     # lista de obras únicas
     obras = [row[0] for row in db.session.query(Solicitacao.obra).distinct().all()]
@@ -201,6 +206,7 @@ def export_template():
 
 
 @bp.route('/api/solicitacoes')
+@login_required
 def api_listar_solicitacoes():
     resultados = []
     for sol in Solicitacao.query.order_by(Solicitacao.id.desc()).all():
@@ -220,6 +226,7 @@ def api_listar_solicitacoes():
 
 
 @bp.route('/api/solicitacoes/<int:id>/aprovar', methods=['POST'])
+@login_required
 def api_aprovar(id):
     sol = Solicitacao.query.get_or_404(id)
     sol.status = 'aprovado'
@@ -229,6 +236,7 @@ def api_aprovar(id):
 
 
 @bp.route('/api/solicitacoes/<int:id>/compras', methods=['POST'])
+@login_required
 def api_compras(id):
     sol = Solicitacao.query.get_or_404(id)
     dados = request.get_json() or {}
@@ -237,3 +245,13 @@ def api_compras(id):
     sol.pendencias = json.dumps(pendencias)
     db.session.commit()
     return jsonify({'ok': True})
+
+
+@bp.route('/solicitacao/<int:id>/delete', methods=['POST'])
+@login_required
+def delete_solicitacao(id):
+    sol = Solicitacao.query.get_or_404(id)
+    db.session.delete(sol)
+    db.session.commit()
+    flash('Solicitação removida.', 'success')
+    return redirect(url_for('projetista.index'))

--- a/site/projetista/templates/base.html
+++ b/site/projetista/templates/base.html
@@ -31,6 +31,11 @@
           <li class="nav-item"><a class="nav-link" href="{{ url_for('projetista.nova_solicitacao') }}">Nova Solicitação</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('projetista.solicitacoes') }}">Ver Solicitações</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('projetista.comparador') }}">Comparador</a></li>
+          {% if current_user.is_authenticated %}
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.logout') }}">Sair</a></li>
+          {% else %}
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.login') }}">Login</a></li>
+          {% endif %}
         </ul>
       </div>
     </div>

--- a/site/projetista/templates/index.html
+++ b/site/projetista/templates/index.html
@@ -1,17 +1,27 @@
 {% extends 'base.html' %}
 {% block body %}
-  <h1>Status das Solicitações</h1>
-  <table class="table table-striped">
+  <h1 class="mb-4">Status das Solicitações</h1>
+  <div class="mb-3 col-md-4">
+    <label for="status-filter" class="form-label">Filtrar por Status</label>
+    <select id="status-filter" class="form-select">
+      <option value="">Todos</option>
+      <option value="analise">Em análise</option>
+      <option value="aprovado">Aprovado</option>
+      <option value="compras">Compras</option>
+    </select>
+  </div>
+  <table id="status-table" class="table table-striped">
     <thead>
       <tr>
         <th>ID</th>
         <th>Obra</th>
         <th>Status</th>
+        <th>Ações</th>
       </tr>
     </thead>
     <tbody>
     {% for sol in solicitacoes %}
-      <tr>
+      <tr data-status="{{ sol.status }}">
         <td>{{ sol.id }}</td>
         <td>{{ sol.obra }}</td>
         <td>
@@ -21,12 +31,31 @@
             {{ sol.status }}
           {% endif %}
         </td>
+        <td>
+          <form method="post" action="{{ url_for('projetista.delete_solicitacao', id=sol.id) }}" onsubmit="return confirm('Confirma apagar?');">
+            <button type="submit" class="btn btn-sm btn-danger">Apagar</button>
+          </form>
+        </td>
       </tr>
     {% else %}
       <tr>
-        <td colspan="3" class="text-muted">Nenhuma solicitação registrada.</td>
+        <td colspan="4" class="text-muted">Nenhuma solicitação registrada.</td>
       </tr>
     {% endfor %}
     </tbody>
   </table>
+
+  <script>
+    const select = document.getElementById('status-filter');
+    select.addEventListener('change', () => {
+      const val = select.value;
+      document.querySelectorAll('#status-table tbody tr').forEach(row => {
+        if (!val || row.dataset.status === val) {
+          row.style.display = '';
+        } else {
+          row.style.display = 'none';
+        }
+      });
+    });
+  </script>
 {% endblock %}

--- a/site/requirements.txt
+++ b/site/requirements.txt
@@ -2,3 +2,4 @@ Flask>=2.3.0
 Flask-SQLAlchemy>=3.0.0
 openpyxl
 pytz
+Flask-Login


### PR DESCRIPTION
## Summary
- add `flask-login` dependency
- introduce `User` model for authentication
- configure login manager in `app.py`
- create auth blueprint with login and logout
- create compras blueprint
- secure projetista routes with authentication and add deletion endpoint
- modernize status page with filter and delete button
- show login/logout links in navbar

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68875e11d670832f820189fe37c2c0b9