### PR TITLE
Add user credential management page

### DIFF
--- a/site/projetista/templates/base.html
+++ b/site/projetista/templates/base.html
@@ -31,6 +31,9 @@
           <li class="nav-item"><a class="nav-link" href="{{ url_for('projetista.nova_solicitacao') }}">Nova Solicitação</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('projetista.solicitacoes') }}">Ver Solicitações</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('projetista.comparador') }}">Comparador</a></li>
+          {% if current_user.is_authenticated and current_user.role == 'admin' %}
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('projetista.config') }}">Configurações</a></li>
+          {% endif %}
           {% if current_user.is_authenticated %}
             <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.logout') }}">Sair</a></li>
           {% else %}

--- a/site/projetista/templates/config.html
+++ b/site/projetista/templates/config.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% block body %}
+<h1 class="h4 mb-4">Configurar Usuários</h1>
+<form method="post">
+  <div class="mb-4">
+    <h2 class="h6">Projetista (admin)</h2>
+    <div class="row g-2">
+      <div class="col-md-4">
+        <label for="admin_username" class="form-label">Usuário</label>
+        <input type="text" class="form-control" id="admin_username" name="admin_username" value="{{ admin_user.username if admin_user else '' }}" required>
+      </div>
+      <div class="col-md-4">
+        <label for="admin_password" class="form-label">Senha</label>
+        <input type="password" class="form-control" id="admin_password" name="admin_password" placeholder="(deixar em branco para manter)">
+      </div>
+    </div>
+  </div>
+  <div class="mb-4">
+    <h2 class="h6">Compras</h2>
+    <div class="row g-2">
+      <div class="col-md-4">
+        <label for="compras_username" class="form-label">Usuário</label>
+        <input type="text" class="form-control" id="compras_username" name="compras_username" value="{{ compras_user.username if compras_user else '' }}" required>
+      </div>
+      <div class="col-md-4">
+        <label for="compras_password" class="form-label">Senha</label>
+        <input type="password" class="form-control" id="compras_password" name="compras_password" placeholder="(deixar em branco para manter)">
+      </div>
+    </div>
+  </div>
+  <button type="submit" class="btn btn-primary">Salvar</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `config` route in `projetista` blueprint to manage user credentials
- show config link in navigation for admin
- create configuration template

## Testing
- `python -m py_compile site/projetista/__init__.py site/auth/__init__.py site/compras/__init__.py site/models.py site/app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688773eed5f0832fbc11d581383336f4