### PR TITLE
Customize compras page and add completion flow

### DIFF
--- a/site/compras/__init__.py
+++ b/site/compras/__init__.py
@@ -1,11 +1,28 @@
-from flask import Blueprint, render_template
+from flask import Blueprint, render_template, redirect, url_for, flash
 from flask_login import login_required
-from models import Solicitacao
+from models import db, Solicitacao
 
 bp = Blueprint('compras', __name__, template_folder='../projetista/templates')
 
 @bp.route('/')
 @login_required
 def index():
-    solicitacoes = Solicitacao.query.order_by(Solicitacao.data.desc()).all()
-    return render_template('index.html', solicitacoes=solicitacoes)
+    """Lista apenas as solicitações que estão com status 'compras'."""
+    solicitacoes = (
+        Solicitacao.query
+        .filter_by(status='compras')
+        .order_by(Solicitacao.data.desc())
+        .all()
+    )
+    return render_template('compras.html', solicitacoes=solicitacoes)
+
+
+@bp.route('/<int:id>/concluir', methods=['POST'])
+@login_required
+def concluir(id: int):
+    """Marca a solicitação como concluída."""
+    sol = Solicitacao.query.get_or_404(id)
+    sol.status = 'concluido'
+    db.session.commit()
+    flash('Solicitação concluída.', 'success')
+    return redirect(url_for('compras.index'))

--- a/site/projetista/templates/compras.html
+++ b/site/projetista/templates/compras.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+{% block body %}
+  <h1 class="mb-4">Solicitações em Compras</h1>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Obra</th>
+        <th>Itens</th>
+        <th>Ação</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for sol in solicitacoes %}
+      <tr>
+        <td>{{ sol.id }}</td>
+        <td>{{ sol.obra }}</td>
+        <td>
+          <ul class="mb-0">
+          {% for it in sol.itens %}
+            <li>{{ it.referencia }} <span class="badge bg-secondary">{{ it.quantidade }}</span></li>
+          {% endfor %}
+          </ul>
+        </td>
+        <td>
+          <form method="post" action="{{ url_for('compras.concluir', id=sol.id) }}">
+            <button type="submit" class="btn btn-sm btn-success">Concluir</button>
+          </form>
+        </td>
+      </tr>
+    {% else %}
+      <tr><td colspan="4" class="text-muted">Nenhuma solicitação em compras.</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}

--- a/site/projetista/templates/index.html
+++ b/site/projetista/templates/index.html
@@ -8,6 +8,7 @@
       <option value="analise">Em análise</option>
       <option value="aprovado">Aprovado</option>
       <option value="compras">Compras</option>
+      <option value="concluido">Concluído</option>
     </select>
   </div>
   <table id="status-table" class="table table-striped">
@@ -27,6 +28,8 @@
         <td>
           {% if sol.status == 'analise' %}
             Em análise
+          {% elif sol.status == 'concluido' %}
+            Concluído
           {% else %}
             {{ sol.status }}
           {% endif %}


### PR DESCRIPTION
## Summary
- filter compras route to show only requests with status `compras`
- add route to mark a request as concluded
- create template to list purchases and allow completion
- show `Concluído` status on projectista home

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887821cda18832fb850dad5cc39eb92