### PR TITLE
Display missing items for compras

### DIFF
--- a/site/compras/__init__.py
+++ b/site/compras/__init__.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, render_template, redirect, url_for, flash
 from flask_login import login_required
 from models import db, Solicitacao
+import json
 
 bp = Blueprint('compras', __name__, template_folder='../projetista/templates')
 
@@ -14,6 +15,14 @@ def index():
         .order_by(Solicitacao.data.desc())
         .all()
     )
+
+    # carrega lista de pendências (itens faltantes) se existir
+    for sol in solicitacoes:
+        try:
+            sol.pendencias_list = json.loads(sol.pendencias or "[]")
+        except json.JSONDecodeError:
+            sol.pendencias_list = []
+
     return render_template('compras.html', solicitacoes=solicitacoes)
 
 

--- a/site/projetista/templates/compras.html
+++ b/site/projetista/templates/compras.html
@@ -7,6 +7,7 @@
         <th>ID</th>
         <th>Obra</th>
         <th>Itens</th>
+        <th>Pendências</th>
         <th>Ação</th>
       </tr>
     </thead>
@@ -23,13 +24,24 @@
           </ul>
         </td>
         <td>
+          {% if sol.pendencias_list %}
+            <ul class="mb-0">
+            {% for p in sol.pendencias_list %}
+              <li>{{ p.referencia }} <span class="badge bg-warning text-dark">{{ p.quantidade }}</span></li>
+            {% endfor %}
+            </ul>
+          {% else %}
+            <span class="text-success">Nenhuma</span>
+          {% endif %}
+        </td>
+        <td>
           <form method="post" action="{{ url_for('compras.concluir', id=sol.id) }}">
             <button type="submit" class="btn btn-sm btn-success">Concluir</button>
           </form>
         </td>
       </tr>
     {% else %}
-      <tr><td colspan="4" class="text-muted">Nenhuma solicitação em compras.</td></tr>
+      <tr><td colspan="5" class="text-muted">Nenhuma solicitação em compras.</td></tr>
     {% endfor %}
     </tbody>
   </table>


### PR DESCRIPTION
## Summary
- show missing items for each solicitação in the compras table
- parse pendências JSON on the server and expose it to the template

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68878c7a9874832f98891d3ee7c0fea7