### PR TITLE
Add dynamic updates and approval status

### DIFF
--- a/site/compras/__init__.py
+++ b/site/compras/__init__.py
@@ -29,9 +29,9 @@ def index():
 @bp.route('/<int:id>/concluir', methods=['POST'])
 @login_required
 def concluir(id: int):
-    """Marca a solicitação como concluída."""
+    """Marca a solicitação como aprovada."""
     sol = Solicitacao.query.get_or_404(id)
-    sol.status = 'concluido'
+    sol.status = 'aprovado'
     db.session.commit()
-    flash('Solicitação concluída.', 'success')
+    flash('Solicitação aprovada.', 'success')
     return redirect(url_for('compras.index'))

--- a/site/projetista/templates/compras.html
+++ b/site/projetista/templates/compras.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block body %}
   <h1 class="mb-4">Solicitações em Compras</h1>
-  <table class="table table-striped">
+  <table id="compras-table" class="table table-striped">
     <thead>
       <tr>
         <th>ID</th>
@@ -45,4 +45,47 @@
     {% endfor %}
     </tbody>
   </table>
+
+  <script>
+    const tbody = document.querySelector('#compras-table tbody');
+
+    function renderPendencias(list) {
+      if (!list || !list.length) {
+        return '<span class="text-success">Nenhuma</span>';
+      }
+      return '<ul class="mb-0">' +
+        list.map(p => `<li>${p.referencia} <span class="badge bg-warning text-dark">${p.quantidade}</span></li>`).join('') +
+        '</ul>';
+    }
+
+    function renderItens(itens) {
+      return '<ul class="mb-0">' +
+        itens.map(it => `<li>${it.referencia} <span class="badge bg-secondary">${it.quantidade}</span></li>`).join('') +
+        '</ul>';
+    }
+
+    async function fetchData() {
+      const resp = await fetch('/projetista/api/solicitacoes');
+      if (!resp.ok) return;
+      const data = await resp.json();
+      tbody.innerHTML = '';
+      data.filter(sol => sol.status === 'compras').forEach(sol => {
+        let row = document.createElement('tr');
+        row.innerHTML = `
+          <td>${sol.id}</td>
+          <td>${sol.obra}</td>
+          <td>${renderItens(sol.itens)}</td>
+          <td>${renderPendencias(JSON.parse(sol.pendencias || '[]'))}</td>
+          <td>
+            <form method="post" action="/compras/${sol.id}/concluir">
+              <button type="submit" class="btn btn-sm btn-success">Concluir</button>
+            </form>
+          </td>`;
+        tbody.appendChild(row);
+      });
+    }
+
+    fetchData();
+    setInterval(fetchData, 5000);
+  </script>
 {% endblock %}

--- a/site/projetista/templates/index.html
+++ b/site/projetista/templates/index.html
@@ -50,15 +50,50 @@
 
   <script>
     const select = document.getElementById('status-filter');
-    select.addEventListener('change', () => {
+    const tbody = document.querySelector('#status-table tbody');
+
+    function applyFilter() {
       const val = select.value;
       document.querySelectorAll('#status-table tbody tr').forEach(row => {
-        if (!val || row.dataset.status === val) {
-          row.style.display = '';
-        } else {
-          row.style.display = 'none';
-        }
+        row.style.display = (!val || row.dataset.status === val) ? '' : 'none';
       });
-    });
+    }
+
+    select.addEventListener('change', applyFilter);
+
+    function renderStatus(status) {
+      const map = {
+        analise: 'Em análise',
+        aprovado: 'Aprovado',
+        compras: 'Compras',
+        concluido: 'Concluído'
+      };
+      return map[status] || status;
+    }
+
+    async function fetchData() {
+      const resp = await fetch('/projetista/api/solicitacoes');
+      if (!resp.ok) return;
+      const data = await resp.json();
+      tbody.innerHTML = '';
+      data.forEach(sol => {
+        const tr = document.createElement('tr');
+        tr.dataset.status = sol.status;
+        tr.innerHTML = `
+          <td>${sol.id}</td>
+          <td>${sol.obra}</td>
+          <td>${renderStatus(sol.status)}</td>
+          <td>
+            <form method="post" action="/projetista/solicitacao/${sol.id}/delete" onsubmit="return confirm('Confirma apagar?');">
+              <button type="submit" class="btn btn-sm btn-danger">Apagar</button>
+            </form>
+          </td>`;
+        tbody.appendChild(tr);
+      });
+      applyFilter();
+    }
+
+    fetchData();
+    setInterval(fetchData, 5000);
   </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- change purchases 'concluir' endpoint to mark requests as `aprovado`
- dynamically refresh status and purchases pages with polling

## Testing
- `python3 -m compileall -q site`

------
https://chatgpt.com/codex/tasks/task_e_68879bbfc630832f98f8c5b64483e136