### PR TITLE
Implement item status management

### DIFF
--- a/site/models.py
+++ b/site/models.py
@@ -6,6 +6,18 @@ from werkzeug.security import generate_password_hash, check_password_hash
 
 db = SQLAlchemy()
 
+# Opções de status individuais para cada item
+ITEM_STATUS_OPTIONS = [
+    'Nao iniciada',
+    'Em cotação',
+    'Fechado',
+    'Faturado',
+    'Entregue',
+    'Separado',
+    'Faturamento',
+    'Cancelado',
+]
+
 class Solicitacao(db.Model):
     __tablename__ = 'solicitacao'
     id = db.Column(db.Integer, primary_key=True)
@@ -22,6 +34,7 @@ class Item(db.Model):
     solicitacao_id = db.Column(db.Integer, db.ForeignKey('solicitacao.id'), nullable=False)
     referencia = db.Column(db.String(100), nullable=False)
     quantidade = db.Column(db.Integer, nullable=False)
+    status = db.Column(db.String(20), default='Nao iniciada')
 
 
 class User(UserMixin, db.Model):

--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -69,7 +69,8 @@ def nova_solicitacao():
                 item = Item(
                     solicitacao_id=sol.id,
                     referencia=str(ref).strip(),
-                    quantidade=int(qt)
+                    quantidade=int(qt),
+                    status='Nao iniciada'
                 )
                 db.session.add(item)
 
@@ -84,7 +85,8 @@ def nova_solicitacao():
                 item = Item(
                     solicitacao_id=sol.id,
                     referencia=ref,
-                    quantidade=int(qt)
+                    quantidade=int(qt),
+                    status='Nao iniciada'
                 )
                 db.session.add(item)
 
@@ -210,7 +212,12 @@ def api_listar_solicitacoes():
     resultados = []
     for sol in Solicitacao.query.order_by(Solicitacao.id.desc()).all():
         itens = [
-            {"referencia": it.referencia, "quantidade": it.quantidade}
+            {
+                "id": it.id,
+                "referencia": it.referencia,
+                "quantidade": it.quantidade,
+                "status": it.status,
+            }
             for it in sol.itens
         ]
         resultados.append({

--- a/site/projetista/templates/compras.html
+++ b/site/projetista/templates/compras.html
@@ -19,7 +19,14 @@
         <td>
           <ul class="mb-0">
           {% for it in sol.itens %}
-            <li>{{ it.referencia }} <span class="badge bg-secondary">{{ it.quantidade }}</span></li>
+            <li>
+              {{ it.referencia }} <span class="badge bg-secondary">{{ it.quantidade }}</span>
+              <select class="form-select form-select-sm d-inline-block w-auto ms-2 item-status" data-item-id="{{ it.id }}">
+                {% for s in status_options %}
+                  <option value="{{ s }}" {% if it.status == s %}selected{% endif %}>{{ s }}</option>
+                {% endfor %}
+              </select>
+            </li>
           {% endfor %}
           </ul>
         </td>
@@ -48,6 +55,7 @@
 
   <script>
     const tbody = document.querySelector('#compras-table tbody');
+    const statusOptions = {{ status_options|tojson }};
 
     function renderPendencias(list) {
       if (!list || !list.length) {
@@ -60,8 +68,28 @@
 
     function renderItens(itens) {
       return '<ul class="mb-0">' +
-        itens.map(it => `<li>${it.referencia} <span class="badge bg-secondary">${it.quantidade}</span></li>`).join('') +
+        itens.map(it => {
+          const opts = statusOptions
+            .map(s => `<option value="${s}" ${it.status === s ? 'selected' : ''}>${s}</option>`) 
+            .join('');
+          return `<li>${it.referencia} <span class="badge bg-secondary">${it.quantidade}</span>` +
+                 `<select class="form-select form-select-sm d-inline-block w-auto ms-2 item-status" data-item-id="${it.id}">${opts}</select></li>`;
+        }).join('') +
         '</ul>';
+    }
+
+    function attachListeners() {
+      document.querySelectorAll('.item-status').forEach(sel => {
+        sel.addEventListener('change', async () => {
+          const id = sel.dataset.itemId;
+          const status = sel.value;
+          await fetch(`/compras/item/${id}/status`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ status })
+          });
+        });
+      });
     }
 
     async function fetchData() {
@@ -83,6 +111,7 @@
           </td>`;
         tbody.appendChild(row);
       });
+      attachListeners();
     }
 
     fetchData();

--- a/site/projetista/templates/solicitacoes.html
+++ b/site/projetista/templates/solicitacoes.html
@@ -28,9 +28,10 @@
           <small class="d-block">{{ sol.local_time.strftime('%d/%m/%Y %H:%M') }}</small>
         </div>
         <ul class="list-group list-group-flush">
-          {% for ref, total in sol.itens_agrupados %}
-            <li class="list-group-item" data-ref="{{ ref|lower }}">
-              {{ ref }} <span class="badge bg-secondary float-end">{{ total }}</span>
+          {% for it in sol.itens %}
+            <li class="list-group-item" data-ref="{{ it.referencia|lower }}">
+              {{ it.referencia }} <span class="badge bg-secondary float-end">{{ it.quantidade }}</span>
+              <small class="d-block text-muted">{{ it.status }}</small>
             </li>
           {% endfor %}
         </ul>


### PR DESCRIPTION
## Summary
- add `status` column to `Item` model and constants for available statuses
- ensure new column is created on startup if missing
- allow setting item status on the compras page
- expose item status via API and show it on the projetista site

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6888fe1fdcb0832f9bfdf716b6edf43f