### PR TITLE
Implement item status management

### DIFF
--- a/site/app.py
+++ b/site/app.py
@@ -7,6 +7,7 @@ from compras import bp as compras_bp
 from auth import bp as auth_bp
 from flask_login import LoginManager, login_user, current_user
 from flask import Flask, request
+from sqlalchemy import inspect
 
 def create_app():
     app = Flask(__name__, template_folder="projetista/templates")
@@ -49,6 +50,17 @@ def create_app():
 
     with app.app_context():
         db.create_all()
+
+        # garante coluna 'status' na tabela item para bancos antigos
+        insp = inspect(db.engine)
+        if 'item' in insp.get_table_names():
+            cols = [c['name'] for c in insp.get_columns('item')]
+            if 'status' not in cols:
+                db.session.execute(
+                    "ALTER TABLE item ADD COLUMN status VARCHAR(20) DEFAULT 'Nao iniciada'"
+                )
+                db.session.commit()
+
         if not User.query.filter_by(username='admin').first():
             admin = User(username='admin', role='admin')
             admin.set_password('admin')

--- a/site/compras/__init__.py
+++ b/site/compras/__init__.py
@@ -1,6 +1,6 @@
-from flask import Blueprint, render_template, redirect, url_for, flash
+from flask import Blueprint, render_template, redirect, url_for, flash, request, jsonify
 from flask_login import login_required
-from models import db, Solicitacao
+from models import db, Solicitacao, Item, ITEM_STATUS_OPTIONS
 import json
 
 bp = Blueprint('compras', __name__, template_folder='../projetista/templates')
@@ -23,7 +23,19 @@ def index():
         except json.JSONDecodeError:
             sol.pendencias_list = []
 
-    return render_template('compras.html', solicitacoes=solicitacoes, hide_navbar=True)
+        # associa id e status do item correspondente em cada pendência
+        for p in sol.pendencias_list:
+            item = next((it for it in sol.itens if it.referencia == p.get("referencia")), None)
+            if item:
+                p["item_id"] = item.id
+                p["status"] = item.status
+
+    return render_template(
+        'compras.html',
+        solicitacoes=solicitacoes,
+        hide_navbar=True,
+        status_options=ITEM_STATUS_OPTIONS,
+    )
 
 
 @bp.route('/<int:id>/concluir', methods=['POST'])
@@ -35,3 +47,17 @@ def concluir(id: int):
     db.session.commit()
     flash('Solicitação aprovada.', 'success')
     return redirect(url_for('compras.index'))
+
+
+@bp.route('/item/<int:item_id>/status', methods=['POST'])
+@login_required
+def atualizar_item_status(item_id: int):
+    """Atualiza o status de um item individual."""
+    item = Item.query.get_or_404(item_id)
+    dados = request.get_json() or {}
+    status = dados.get('status')
+    if status not in ITEM_STATUS_OPTIONS:
+        return jsonify({'ok': False, 'error': 'status inválido'}), 400
+    item.status = status
+    db.session.commit()
+    return jsonify({'ok': True})

--- a/site/models.py
+++ b/site/models.py
@@ -6,6 +6,18 @@ from werkzeug.security import generate_password_hash, check_password_hash
 
 db = SQLAlchemy()
 
+# Opções de status individuais para cada item
+ITEM_STATUS_OPTIONS = [
+    'Nao iniciada',
+    'Em cotação',
+    'Fechado',
+    'Faturado',
+    'Entregue',
+    'Separado',
+    'Faturamento',
+    'Cancelado',
+]
+
 class Solicitacao(db.Model):
     __tablename__ = 'solicitacao'
     id = db.Column(db.Integer, primary_key=True)
@@ -22,6 +34,7 @@ class Item(db.Model):
     solicitacao_id = db.Column(db.Integer, db.ForeignKey('solicitacao.id'), nullable=False)
     referencia = db.Column(db.String(100), nullable=False)
     quantidade = db.Column(db.Integer, nullable=False)
+    status = db.Column(db.String(20), default='Nao iniciada')
 
 
 class User(UserMixin, db.Model):

--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -69,7 +69,8 @@ def nova_solicitacao():
                 item = Item(
                     solicitacao_id=sol.id,
                     referencia=str(ref).strip(),
-                    quantidade=int(qt)
+                    quantidade=int(qt),
+                    status='Nao iniciada'
                 )
                 db.session.add(item)
 
@@ -84,7 +85,8 @@ def nova_solicitacao():
                 item = Item(
                     solicitacao_id=sol.id,
                     referencia=ref,
-                    quantidade=int(qt)
+                    quantidade=int(qt),
+                    status='Nao iniciada'
                 )
                 db.session.add(item)
 
@@ -210,7 +212,12 @@ def api_listar_solicitacoes():
     resultados = []
     for sol in Solicitacao.query.order_by(Solicitacao.id.desc()).all():
         itens = [
-            {"referencia": it.referencia, "quantidade": it.quantidade}
+            {
+                "id": it.id,
+                "referencia": it.referencia,
+                "quantidade": it.quantidade,
+                "status": it.status,
+            }
             for it in sol.itens
         ]
         resultados.append({

--- a/site/projetista/templates/compras.html
+++ b/site/projetista/templates/compras.html
@@ -27,7 +27,14 @@
           {% if sol.pendencias_list %}
             <ul class="mb-0">
             {% for p in sol.pendencias_list %}
-              <li>{{ p.referencia }} <span class="badge bg-warning text-dark">{{ p.quantidade }}</span></li>
+              <li>
+                {{ p.referencia }} <span class="badge bg-warning text-dark">{{ p.quantidade }}</span>
+                <select class="form-select form-select-sm d-inline-block w-auto ms-2 item-status" data-item-id="{{ p.item_id }}">
+                  {% for s in status_options %}
+                    <option value="{{ s }}" {% if p.status == s %}selected{% endif %}>{{ s }}</option>
+                  {% endfor %}
+                </select>
+              </li>
             {% endfor %}
             </ul>
           {% else %}
@@ -48,13 +55,21 @@
 
   <script>
     const tbody = document.querySelector('#compras-table tbody');
+    const statusOptions = {{ status_options|tojson }};
 
-    function renderPendencias(list) {
+    function renderPendencias(list, itens) {
       if (!list || !list.length) {
         return '<span class="text-success">Nenhuma</span>';
       }
       return '<ul class="mb-0">' +
-        list.map(p => `<li>${p.referencia} <span class="badge bg-warning text-dark">${p.quantidade}</span></li>`).join('') +
+        list.map(p => {
+          const it = itens.find(i => i.referencia === p.referencia) || {};
+          const opts = statusOptions
+            .map(s => `<option value="${s}" ${it.status === s ? 'selected' : ''}>${s}</option>`)
+            .join('');
+          return `<li>${p.referencia} <span class="badge bg-warning text-dark">${p.quantidade}</span>` +
+                 `<select class="form-select form-select-sm d-inline-block w-auto ms-2 item-status" data-item-id="${it.id || ''}">${opts}</select></li>`;
+        }).join('') +
         '</ul>';
     }
 
@@ -62,6 +77,20 @@
       return '<ul class="mb-0">' +
         itens.map(it => `<li>${it.referencia} <span class="badge bg-secondary">${it.quantidade}</span></li>`).join('') +
         '</ul>';
+    }
+
+    function attachListeners() {
+      document.querySelectorAll('.item-status').forEach(sel => {
+        sel.addEventListener('change', async () => {
+          const id = sel.dataset.itemId;
+          const status = sel.value;
+          await fetch(`/compras/item/${id}/status`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ status })
+          });
+        });
+      });
     }
 
     async function fetchData() {
@@ -75,7 +104,7 @@
           <td>${sol.id}</td>
           <td>${sol.obra}</td>
           <td>${renderItens(sol.itens)}</td>
-          <td>${renderPendencias(JSON.parse(sol.pendencias || '[]'))}</td>
+          <td>${renderPendencias(JSON.parse(sol.pendencias || '[]'), sol.itens)}</td>
           <td>
             <form method="post" action="/compras/${sol.id}/concluir">
               <button type="submit" class="btn btn-sm btn-success">Concluir</button>
@@ -83,6 +112,7 @@
           </td>`;
         tbody.appendChild(row);
       });
+      attachListeners();
     }
 
     fetchData();

--- a/site/projetista/templates/solicitacoes.html
+++ b/site/projetista/templates/solicitacoes.html
@@ -28,9 +28,10 @@
           <small class="d-block">{{ sol.local_time.strftime('%d/%m/%Y %H:%M') }}</small>
         </div>
         <ul class="list-group list-group-flush">
-          {% for ref, total in sol.itens_agrupados %}
-            <li class="list-group-item" data-ref="{{ ref|lower }}">
-              {{ ref }} <span class="badge bg-secondary float-end">{{ total }}</span>
+          {% for it in sol.itens %}
+            <li class="list-group-item" data-ref="{{ it.referencia|lower }}">
+              {{ it.referencia }} <span class="badge bg-secondary float-end">{{ it.quantidade }}</span>
+              <small class="d-block text-muted">{{ it.status }}</small>
             </li>
           {% endfor %}
         </ul>


### PR DESCRIPTION
## Summary
- add per-item status options and default column
- ensure Item table gets new status column on startup if missing
- enable updating item status from the compras page
- list item statuses on the projetista page
- move status dropdown to "Pendências" column only
- clean up unused import

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6888fe1fdcb0832f9bfdf716b6edf43f