### PR TITLE
Fix purchase item status script

### DIFF
--- a/site/projetista/templates/compras.html
+++ b/site/projetista/templates/compras.html
@@ -62,7 +62,7 @@
 
   <script>
     const tbody = document.querySelector('#compras-table tbody');
-    const statusOptions = {{ status_options|tojson }};
+    const statusOptions = {{ status_options|tojson|safe }};
 
     function renderPendencias(list, itens) {
       if (!list || !list.length) {


### PR DESCRIPTION
## Summary
- ensure status options JSON in compras template isn't escaped so the constant name isn't rendered

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688908f9870c832fb47f0a4224e5fc36