### PR TITLE
Fix purchase item status script

### DIFF
--- a/site/projetista/templates/compras.html
+++ b/site/projetista/templates/compras.html
@@ -21,11 +21,6 @@
           {% for it in sol.itens %}
             <li>
               {{ it.referencia }} <span class="badge bg-secondary">{{ it.quantidade }}</span>
-              <select class="form-select form-select-sm d-inline-block w-auto ms-2 item-status" data-item-id="{{ it.id }}">
-                {% for s in status_options %}
-                  <option value="{{ s }}" {% if it.status == s %}selected{% endif %}>{{ s }}</option>
-                {% endfor %}
-              </select>
             </li>
           {% endfor %}
           </ul>
@@ -62,7 +57,7 @@
 
   <script>
     const tbody = document.querySelector('#compras-table tbody');
-    const statusOptions = {{ status_options|tojson }};
+    const statusOptions = {{ status_options|tojson|safe }};
 
     function renderPendencias(list, itens) {
       if (!list || !list.length) {
@@ -83,11 +78,7 @@
     function renderItens(itens) {
       return '<ul class="mb-0">' +
         itens.map(it => {
-          const opts = statusOptions
-            .map(s => `<option value="${s}" ${it.status === s ? 'selected' : ''}>${s}</option>`) 
-            .join('');
-          return `<li>${it.referencia} <span class="badge bg-secondary">${it.quantidade}</span>` +
-                 `<select class="form-select form-select-sm d-inline-block w-auto ms-2 item-status" data-item-id="${it.id}">${opts}</select></li>`;
+          return `<li>${it.referencia} <span class="badge bg-secondary">${it.quantidade}</span></li>`;
         }).join('') +
         '</ul>';
     }


### PR DESCRIPTION
## Summary
- ensure status options JSON in compras template isn't escaped so the constant name isn't rendered
- remove status dropdowns from the "Itens" column

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688908f9870c832fb47f0a4224e5fc36