### PR TITLE
Display stock label for pendências

### DIFF
--- a/site/projetista/templates/compras.html
+++ b/site/projetista/templates/compras.html
@@ -27,18 +27,20 @@
         </td>
         <td>
           {% if sol.pendencias_list %}
-            <ul class="mb-0">
-            {% for p in sol.pendencias_list %}
-              <li>
-                {{ p.referencia }} <span class="badge bg-warning text-dark">{{ p.quantidade }}</span>
-                <select class="form-select form-select-sm d-inline-block w-auto ms-2 item-status" data-item-id="{{ p.item_id }}">
-                  {% for s in status_options %}
-                    <option value="{{ s }}" {% if p.status == s %}selected{% endif %}>{{ s }}</option>
-                  {% endfor %}
-                </select>
-              </li>
-            {% endfor %}
-            </ul>
+              <ul class="mb-0">
+              {% for p in sol.pendencias_list %}
+                <li>
+                  {{ p.referencia }}
+                  <div class="small text-muted">Tem no estoque:</div>
+                  <span class="badge bg-warning text-dark">{{ p.quantidade }}</span>
+                  <select class="form-select form-select-sm d-inline-block w-auto ms-2 item-status" data-item-id="{{ p.item_id }}">
+                    {% for s in status_options %}
+                      <option value="{{ s }}" {% if p.status == s %}selected{% endif %}>{{ s }}</option>
+                    {% endfor %}
+                  </select>
+                </li>
+              {% endfor %}
+              </ul>
           {% else %}
             <span class="text-success">Nenhuma</span>
           {% endif %}
@@ -69,7 +71,8 @@
           const opts = statusOptions
             .map(s => `<option value="${s}" ${it.status === s ? 'selected' : ''}>${s}</option>`)
             .join('');
-          return `<li>${p.referencia} <span class="badge bg-warning text-dark">${p.quantidade}</span>` +
+          return `<li>${p.referencia}<div class="small text-muted">Tem no estoque:</div>` +
+                 `<span class="badge bg-warning text-dark">${p.quantidade}</span>` +
                  `<select class="form-select form-select-sm d-inline-block w-auto ms-2 item-status" data-item-id="${it.id || ''}">${opts}</select></li>`;
         }).join('') +
         '</ul>';


### PR DESCRIPTION
## Summary
- update `compras.html` to show label "Tem no estoque:" above the quantity of missing items
- adjust client-side rendering logic accordingly

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688923a5c6e4832fbbfe480c652fe54a