### PR TITLE
Add item status history tracker

### DIFF
--- a/site/compras/__init__.py
+++ b/site/compras/__init__.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, render_template, redirect, url_for, flash, request, jsonify
 from flask_login import login_required
-from models import db, Solicitacao, Item, ITEM_STATUS_OPTIONS
+from models import db, Solicitacao, Item, ITEM_STATUS_OPTIONS, ItemStatusHistory
 import json
 
 bp = Blueprint('compras', __name__, template_folder='../projetista/templates')
@@ -53,6 +53,34 @@ def atualizar_item_status(item_id: int):
     status = dados.get('status')
     if status not in ITEM_STATUS_OPTIONS:
         return jsonify({'ok': False, 'error': 'status inválido'}), 400
+    old = item.status
     item.status = status
+    db.session.add(ItemStatusHistory(
+        item_id=item.id,
+        old_status=old,
+        new_status=status,
+    ))
     db.session.commit()
     return jsonify({'ok': True})
+
+
+@bp.route('/item/<int:item_id>/history')
+@login_required
+def item_history(item_id: int):
+    """Retorna o histórico de status do item."""
+    item = Item.query.get_or_404(item_id)
+    historico = (
+        ItemStatusHistory.query
+        .filter_by(item_id=item.id)
+        .order_by(ItemStatusHistory.changed_at.asc())
+        .all()
+    )
+    data = [
+        {
+            'old_status': h.old_status,
+            'new_status': h.new_status,
+            'changed_at': h.changed_at.isoformat(),
+        }
+        for h in historico
+    ]
+    return jsonify(data)

--- a/site/models.py
+++ b/site/models.py
@@ -37,6 +37,17 @@ class Item(db.Model):
     status = db.Column(db.String(20), default='Nao iniciada')
 
 
+class ItemStatusHistory(db.Model):
+    """Historico de mudancas de status de um item."""
+    __tablename__ = 'item_status_history'
+
+    id = db.Column(db.Integer, primary_key=True)
+    item_id = db.Column(db.Integer, db.ForeignKey('item.id'), nullable=False)
+    old_status = db.Column(db.String(20), nullable=False)
+    new_status = db.Column(db.String(20), nullable=False)
+    changed_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
 class User(UserMixin, db.Model):
     __tablename__ = 'user'
     id = db.Column(db.Integer, primary_key=True)

--- a/site/projetista/templates/compras.html
+++ b/site/projetista/templates/compras.html
@@ -33,11 +33,18 @@
                   {{ p.referencia }}
                   <div class="small text-muted">Falta:</div>
                   <span class="badge bg-warning text-dark">{{ p.quantidade }}</span>
-                  <select class="form-select form-select-sm d-inline-block w-auto ms-2 item-status" data-item-id="{{ p.item_id }}">
+                  {% set item_id = None %}
+                  {% for it in sol.itens %}
+                    {% if it.referencia == p.referencia %}
+                      {% set item_id = it.id %}
+                    {% endif %}
+                  {% endfor %}
+                  <select class="form-select form-select-sm d-inline-block w-auto ms-2 item-status" data-item-id="{{ item_id }}">
                     {% for s in status_options %}
                       <option value="{{ s }}" {% if p.status == s %}selected{% endif %}>{{ s }}</option>
                     {% endfor %}
                   </select>
+                  <button type="button" class="btn btn-sm btn-info ms-1 btn-history" data-item-id="{{ item_id }}">Histórico</button>
                 </li>
               {% endfor %}
               </ul>
@@ -57,6 +64,20 @@
     </tbody>
   </table>
 
+  <div class="modal fade" id="historyModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="historyModalLabel">Histórico de Status</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <ul id="historyList" class="list-group mb-0"></ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <script>
     const tbody = document.querySelector('#compras-table tbody');
     const statusOptions = {{ status_options|tojson|safe }};
@@ -73,7 +94,9 @@
             .join('');
           return `<li>${p.referencia}<div class="small text-muted">Falta:</div>` +
                  `<span class="badge bg-warning text-dark">${p.quantidade}</span>` +
-                 `<select class="form-select form-select-sm d-inline-block w-auto ms-2 item-status" data-item-id="${it.id || ''}">${opts}</select></li>`;
+                 `<select class="form-select form-select-sm d-inline-block w-auto ms-2 item-status" data-item-id="${it.id || ''}">${opts}</select>` +
+                 `<button type="button" class="btn btn-sm btn-info ms-1 btn-history" data-item-id="${it.id || ''}">Histórico</button>` +
+                 `</li>`;
         }).join('') +
         '</ul>';
     }
@@ -111,6 +134,27 @@
           updateButtonState(sel.closest('tr'));
         });
       });
+
+      document.querySelectorAll('.btn-history').forEach(btn => {
+        btn.addEventListener('click', () => showHistory(btn.dataset.itemId));
+      });
+    }
+
+    async function showHistory(itemId) {
+      const resp = await fetch(`/compras/item/${itemId}/history`);
+      if (!resp.ok) return;
+      const data = await resp.json();
+      const list = document.getElementById('historyList');
+      list.innerHTML = '';
+      data.forEach(h => {
+        const li = document.createElement('li');
+        const dt = new Date(h.changed_at);
+        li.className = 'list-group-item';
+        li.textContent = `${dt.toLocaleString()} : ${h.old_status} → ${h.new_status}`;
+        list.appendChild(li);
+      });
+      const modal = new bootstrap.Modal(document.getElementById('historyModal'));
+      modal.show();
     }
 
     async function fetchData() {


### PR DESCRIPTION
## Summary
- track item status changes with `ItemStatusHistory`
- log status updates in purchases blueprint
- expose history endpoint
- show modal button and fetch history in purchases UI

## Testing
- `python -m py_compile site/compras/__init__.py site/models.py`

------
https://chatgpt.com/codex/tasks/task_e_688a4634dbcc832fa09e1119a35f075f