### PR TITLE
Improve compras page UI and add logout option

### DIFF
--- a/site/auth/templates/login.html
+++ b/site/auth/templates/login.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="utf-8">
   <title>Login</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+  <!-- Bootswatch Lux theme for consistency -->
+  <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.1/dist/lux/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
 </head>
 <body class="bg-light d-flex justify-content-center align-items-center" style="height:100vh;">
   <div class="card p-4 shadow" style="min-width:300px;">

--- a/site/projetista/templates/base.html
+++ b/site/projetista/templates/base.html
@@ -4,10 +4,10 @@
   <meta charset="utf-8">
   <title>Projetista</title>
 
-  <!-- Bootstrap 5 CSS -->
-  <link 
-    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" 
-    rel="stylesheet" 
+  <!-- Bootswatch Lux theme for a modern look -->
+  <link
+    href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.1/dist/lux/bootstrap.min.css"
+    rel="stylesheet"
     crossorigin="anonymous"
   >
   <link 

--- a/site/projetista/templates/compras.html
+++ b/site/projetista/templates/compras.html
@@ -1,6 +1,25 @@
 {% extends 'base.html' %}
 {% block body %}
-  <h1 class="mb-4">Solicitações em Compras</h1>
+  <style>
+    body {
+      background: linear-gradient(135deg, #141e30 0%, #243b55 100%);
+      color: #f8f9fa;
+    }
+    .card {
+      background-color: rgba(255,255,255,0.05);
+      border: 1px solid rgba(255,255,255,0.1);
+      backdrop-filter: blur(6px);
+    }
+    .card-header {
+      background-color: rgba(0,0,0,0.4);
+    }
+  </style>
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="mb-0">Solicitações em Compras</h1>
+    {% if current_user.is_authenticated %}
+      <a href="{{ url_for('auth.logout') }}" class="btn btn-danger">Sair</a>
+    {% endif %}
+  </div>
   <div id="compras-container" class="row gy-4">
     {% for sol in solicitacoes %}
       <div class="col-md-6 col-lg-4 compra-card">


### PR DESCRIPTION
## Summary
- switch to the Bootswatch *Lux* theme for a more modern interface
- modernize the compras page with gradient background, glass-style cards
- add visible logout button on the compras page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a4f31ad44832fa232c322ef6dd629