### PR TITLE
Add collapse for solicitacao cards and slim navbar

### DIFF
--- a/site/projetista/templates/base.html
+++ b/site/projetista/templates/base.html
@@ -16,7 +16,7 @@
   >
   <style>
     {% if not hide_navbar %}
-      body { padding-top: 4.5rem; }
+      body { padding-top: 4rem; }
     {% endif %}
   </style>
 </head>
@@ -24,7 +24,7 @@
 
   {% if not hide_navbar %}
     <!-- Navbar -->
-    <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top shadow-sm">
+    <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top shadow-sm py-1">
       <div class="container">
         <a class="navbar-brand" href="{{ url_for('projetista.index') }}">Solicitação do Projetista</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navMenu">

--- a/site/projetista/templates/solicitacoes.html
+++ b/site/projetista/templates/solicitacoes.html
@@ -17,17 +17,22 @@
   </div>
 </div>
 
-<div id="solicitacoes-container" class="row gy-4">
+  <div id="solicitacoes-container" class="row gy-4">
   {% for sol in solicitacoes %}
-    <div class="col-md-6 col-lg-4 solicitacao-card" 
-         data-id="{{ sol.id|string }}" 
+    <div class="col-md-6 col-lg-4 solicitacao-card"
+         data-id="{{ sol.id|string }}"
          data-obra="{{ sol.obra|lower }}">
       <div class="card h-100 shadow-sm">
-        <div class="card-header bg-primary text-white">
-          <strong>#{{ sol.id }}</strong> – {{ sol.obra }}
-          <small class="d-block">{{ sol.local_time.strftime('%d/%m/%Y %H:%M') }}</small>
+        <div class="card-header bg-primary text-white d-flex justify-content-between align-items-start">
+          <div>
+            <strong>#{{ sol.id }}</strong> – {{ sol.obra }}
+            <small class="d-block">{{ sol.local_time.strftime('%d/%m/%Y %H:%M') }}</small>
+          </div>
+          <button class="btn btn-light btn-sm" type="button" data-bs-toggle="collapse" data-bs-target="#itens-{{ sol.id }}" aria-expanded="false" aria-controls="itens-{{ sol.id }}">
+            Detalhes
+          </button>
         </div>
-        <ul class="list-group list-group-flush">
+        <ul id="itens-{{ sol.id }}" class="list-group list-group-flush collapse">
           {% for it in sol.itens %}
             <li class="list-group-item" data-ref="{{ it.referencia|lower }}">
               {{ it.referencia }} <span class="badge bg-secondary float-end">{{ it.quantidade }}</span>


### PR DESCRIPTION
## Summary
- tweak navbar padding to reduce height
- collapse solicitacao cards so details can be toggled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a530e8d28832fae9518c8513d666b