### PR TITLE
Update request header color

### DIFF
--- a/site/projetista/templates/solicitacoes.html
+++ b/site/projetista/templates/solicitacoes.html
@@ -23,7 +23,7 @@
          data-id="{{ sol.id|string }}"
          data-obra="{{ sol.obra|lower }}">
       <div class="card h-100 shadow-sm">
-        <div class="card-header bg-primary text-white d-flex justify-content-between align-items-start">
+        <div class="card-header text-white d-flex justify-content-between align-items-start {% if sol.status == 'aprovado' %}bg-success{% else %}bg-primary{% endif %}">
           <div>
             <strong>#{{ sol.id }}</strong> – {{ sol.obra }}
             <small class="d-block">{{ sol.local_time.strftime('%d/%m/%Y %H:%M') }}</small>


### PR DESCRIPTION
## Summary
- show request card header in green when request is approved

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a5769b828832f85f06eaafee50ed8