### PR TITLE
Ajustes em compras

### DIFF
--- a/site/compras/__init__.py
+++ b/site/compras/__init__.py
@@ -36,11 +36,12 @@ def index():
 @bp.route('/<int:id>/concluir', methods=['POST'])
 @login_required
 def concluir(id: int):
-    """Marca a solicitação como aprovada."""
+    """Reenvia a solicitação para o checklist."""
     sol = Solicitacao.query.get_or_404(id)
-    sol.status = 'aprovado'
+    sol.status = 'analise'
+    sol.pendencias = None
     db.session.commit()
-    flash('Solicitação aprovada.', 'success')
+    flash('Solicitação reenviada para checklist.', 'success')
     return redirect(url_for('compras.index'))
 
 

--- a/site/models.py
+++ b/site/models.py
@@ -13,7 +13,6 @@ ITEM_STATUS_OPTIONS = [
     'Fechado',
     'Faturado',
     'Entregue',
-    'Separado',
     'Faturamento',
     'Cancelado',
 ]

--- a/site/projetista/templates/compras.html
+++ b/site/projetista/templates/compras.html
@@ -2,7 +2,14 @@
 {% block body %}
   <style>
     body {
-
+      background: linear-gradient(135deg, #f8f9fa, #e9ecef);
+    }
+    .compra-card .card {
+      border-color: #ced4da;
+    }
+    .compra-card .card-header {
+      background-color: #0d6efd;
+      color: #fff;
     }
   </style>
   <div class="d-flex justify-content-between align-items-center mb-4">


### PR DESCRIPTION
## Resumo
- reenviar solicitações de compras para o checklist quando concluídas
- remover opção **Separado** dos status de item
- alterar visual da página de compras com plano de fundo gradiente

## Testes
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a60203d38832f81f6c0b3e20403f0