### PR TITLE
Add Iniciar Projeto page to navbar

### DIFF
--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -47,6 +47,24 @@ def solicitacoes():
     return render_template('solicitacoes.html', solicitacoes=consulta)
 
 
+@bp.route('/iniciar_projeto')
+@login_required
+def iniciar_projeto():
+    """Exibe os projetos divididos por status."""
+    consulta = Solicitacao.query.order_by(Solicitacao.data.desc()).all()
+
+    analise = [s for s in consulta if s.status == 'analise']
+    aprovado = [s for s in consulta if s.status == 'aprovado']
+    compras = [s for s in consulta if s.status == 'compras']
+
+    return render_template(
+        'iniciar_projeto.html',
+        analise=analise,
+        aprovado=aprovado,
+        compras=compras,
+    )
+
+
 @bp.route('/solicitacao/nova', methods=['GET', 'POST'])
 @login_required
 def nova_solicitacao():

--- a/site/projetista/templates/base.html
+++ b/site/projetista/templates/base.html
@@ -35,6 +35,7 @@
             <li class="nav-item"><a class="nav-link" href="{{ url_for('projetista.index') }}">Home</a></li>
             <li class="nav-item"><a class="nav-link" href="{{ url_for('projetista.nova_solicitacao') }}">Nova Solicitação</a></li>
             <li class="nav-item"><a class="nav-link" href="{{ url_for('projetista.solicitacoes') }}">Historico de Solicitações</a></li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('projetista.iniciar_projeto') }}">Iniciar Projeto</a></li>
             <li class="nav-item"><a class="nav-link" href="{{ url_for('projetista.comparador') }}">Comparador</a></li>
             {% if current_user.is_authenticated and current_user.role == 'admin' %}
               <li class="nav-item"><a class="nav-link" href="{{ url_for('projetista.config') }}">Configurações</a></li>

--- a/site/projetista/templates/iniciar_projeto.html
+++ b/site/projetista/templates/iniciar_projeto.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+{% block body %}
+<h1 class="mb-4">Iniciar Projeto</h1>
+<div class="row">
+  <div class="col-md-4">
+    <h4>Aguardando Andamento</h4>
+    <ul class="list-group mb-4">
+      {% for s in analise %}
+      <li class="list-group-item">#{{ s.id }} - {{ s.obra }}</li>
+      {% else %}
+      <li class="list-group-item text-muted">Nenhum projeto.</li>
+      {% endfor %}
+    </ul>
+  </div>
+  <div class="col-md-4">
+    <h4>Separado</h4>
+    <ul class="list-group mb-4">
+      {% for s in aprovado %}
+      <li class="list-group-item">#{{ s.id }} - {{ s.obra }}</li>
+      {% else %}
+      <li class="list-group-item text-muted">Nenhum projeto.</li>
+      {% endfor %}
+    </ul>
+  </div>
+  <div class="col-md-4">
+    <h4>Pendente em compras</h4>
+    <ul class="list-group mb-4">
+      {% for s in compras %}
+      <li class="list-group-item">#{{ s.id }} - {{ s.obra }}</li>
+      {% else %}
+      <li class="list-group-item text-muted">Nenhum projeto.</li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add new route to view projects grouped by status
- create `iniciar_projeto.html` template
- link new page from navbar

## Testing
- `python -m py_compile site/app.py site/projetista/__init__.py site/compras/__init__.py site/auth/__init__.py site/models.py`

------
https://chatgpt.com/codex/tasks/task_e_688b62e10c0c832fb4f3166c31474abb