### PR TITLE
Add tabbed screens to APPproducao

### DIFF
--- a/APPproducao/app/build.gradle.kts
+++ b/APPproducao/app/build.gradle.kts
@@ -49,6 +49,12 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    // Networking
+    implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation("com.squareup.retrofit2:converter-moshi:2.9.0")
+    implementation("com.squareup.okhttp3:logging-interceptor:5.0.0-alpha.11")
+    implementation("com.squareup.moshi:moshi-kotlin:1.15.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/APPproducao/app/src/main/java/com/example/appproducao/MainActivity.kt
+++ b/APPproducao/app/src/main/java/com/example/appproducao/MainActivity.kt
@@ -3,27 +3,30 @@ package com.example.appproducao
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.tooling.preview.Preview
+import com.example.appproducao.data.NetworkModule
+import com.example.appproducao.data.Solicitacao
 import com.example.appproducao.ui.theme.AppProducaoTheme
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
         setContent {
             AppProducaoTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    MainScreen()
                 }
             }
         }
@@ -31,17 +34,80 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
+fun MainScreen() {
+    var selected by remember { mutableStateOf(0) }
+    val tabs = listOf("Iniciar", "Em produção")
+    Column {
+        TabRow(selectedTabIndex = selected) {
+            tabs.forEachIndexed { index, title ->
+                Tab(
+                    text = { Text(title) },
+                    selected = selected == index,
+                    onClick = { selected = index }
+                )
+            }
+        }
+        when (selected) {
+            0 -> IniciarScreen()
+            else -> EmProducaoScreen()
+        }
+    }
+}
+
+@Composable
+fun IniciarScreen() {
+    var solicitacoes by remember { mutableStateOf<List<Solicitacao>>(emptyList()) }
+    var error by remember { mutableStateOf<String?>(null) }
+    var loading by remember { mutableStateOf(true) }
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(Unit) {
+        scope.launch {
+            try {
+                val all = NetworkModule.api.listarSolicitacoes()
+                solicitacoes = all.filter { it.status?.lowercase() == "separado" }
+            } catch (e: Exception) {
+                error = e.localizedMessage
+            } finally {
+                loading = false
+            }
+        }
+    }
+
+    when {
+        loading -> {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        }
+        error != null -> {
+            Text("Erro: ${'$'}error", modifier = Modifier.padding(16.dp))
+        }
+        else -> {
+            LazyColumn {
+                items(solicitacoes) { sol ->
+                    Text(
+                        text = "${'$'}{sol.obra} - id ${'$'}{sol.id}",
+                        modifier = Modifier.padding(16.dp)
+                    )
+                    Divider()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun EmProducaoScreen() {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text("Em produção")
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
-fun GreetingPreview() {
+fun DefaultPreview() {
     AppProducaoTheme {
-        Greeting("Android")
+        MainScreen()
     }
 }

--- a/APPproducao/app/src/main/java/com/example/appproducao/data/ApiService.kt
+++ b/APPproducao/app/src/main/java/com/example/appproducao/data/ApiService.kt
@@ -1,0 +1,20 @@
+package com.example.appproducao.data
+
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface ApiService {
+    @GET("api/solicitacoes")
+    suspend fun listarSolicitacoes(): List<Solicitacao>
+
+    @POST("api/solicitacoes/{id}/aprovar")
+    suspend fun aprovarSolicitacao(@Path("id") id: Int)
+
+    @POST("api/solicitacoes/{id}/compras")
+    suspend fun marcarCompras(
+        @Path("id") id: Int,
+        @Body body: ComprasRequest
+    )
+}

--- a/APPproducao/app/src/main/java/com/example/appproducao/data/ComprasRequest.kt
+++ b/APPproducao/app/src/main/java/com/example/appproducao/data/ComprasRequest.kt
@@ -1,0 +1,8 @@
+package com.example.appproducao.data
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class ComprasRequest(
+    val pendencias: List<Item>
+)

--- a/APPproducao/app/src/main/java/com/example/appproducao/data/NetworkModule.kt
+++ b/APPproducao/app/src/main/java/com/example/appproducao/data/NetworkModule.kt
@@ -1,0 +1,28 @@
+package com.example.appproducao.data
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+object NetworkModule {
+    private val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+
+    private val client: OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor(HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BASIC
+        })
+        .build()
+
+    private val retrofit = Retrofit.Builder()
+        .baseUrl("http://192.168.0.135:5000/projetista/")
+        .addConverterFactory(MoshiConverterFactory.create(moshi))
+        .client(client)
+        .build()
+
+    val api: ApiService = retrofit.create(ApiService::class.java)
+}

--- a/APPproducao/app/src/main/java/com/example/appproducao/data/Solicitacao.kt
+++ b/APPproducao/app/src/main/java/com/example/appproducao/data/Solicitacao.kt
@@ -1,0 +1,19 @@
+package com.example.appproducao.data
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class Item(
+    val referencia: String,
+    val quantidade: Int
+)
+
+@JsonClass(generateAdapter = true)
+data class Solicitacao(
+    val id: Int,
+    val obra: String,
+    val data: String,
+    val itens: List<Item>,
+    val status: String? = null,
+    val pendencias: String? = null
+)


### PR DESCRIPTION
## Summary
- add retrofit/moshi/coroutines deps
- implement tab layout in `MainActivity`
- fetch solicitacoes and filter for status "separado"
- add networking data layer for Compose app

## Testing
- `sh APPproducao/gradlew -p APPproducao help` *(fails: Unable to download Gradle due to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688b909bce80832fac81de62e4133fb7