### PR TITLE
Add unconditional approval

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistActivity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistActivity.kt
@@ -49,13 +49,13 @@ class ChecklistActivity : AppCompatActivity() {
         val btn = findViewById<Button>(R.id.btnConcluir)
         btn.setOnClickListener {
             val pendentes = solicitacao.itens.filterIndexed { index, _ -> !checks[index].isChecked }
+
             lifecycleScope.launch {
                 try {
                     withContext(Dispatchers.IO) {
-                        if (pendentes.isEmpty()) {
-                            NetworkModule.api.aprovarSolicitacao(solicitacao.id)
-                        }
+                        NetworkModule.api.aprovarSolicitacao(solicitacao.id)
                     }
+
                     if (pendentes.isEmpty()) {
                         setResult(Activity.RESULT_OK)
                         finish()

--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -266,7 +266,8 @@ def api_compras(id):
     sol = Solicitacao.query.get_or_404(id)
     dados = request.get_json() or {}
     pendencias = dados.get('pendencias', [])
-    sol.status = 'compras'
+    if sol.status != 'aprovado':
+        sol.status = 'compras'
     sol.pendencias = json.dumps(pendencias)
     db.session.commit()
     return jsonify({'ok': True})


### PR DESCRIPTION
## Summary
- approve requests no matter how many checklist items are completed
- keep approved status when forwarding pending items to compras

## Testing
- `python3 -m py_compile site/*.py site/*/*.py`
- `bash ./AppEstoque/gradlew --version` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688ba7bfaf90832f96b6a53767d2ab67