### PR TITLE
Add 80% approval rule

### DIFF
--- a/APPproducao/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistActivity.kt
+++ b/APPproducao/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistActivity.kt
@@ -49,10 +49,14 @@ class ChecklistActivity : AppCompatActivity() {
         val btn = findViewById<Button>(R.id.btnConcluir)
         btn.setOnClickListener {
             val pendentes = solicitacao.itens.filterIndexed { index, _ -> !checks[index].isChecked }
+
+            val checkedCount = checks.count { it.isChecked }
+            val completion = checkedCount.toDouble() / checks.size
+
             lifecycleScope.launch {
                 try {
                     withContext(Dispatchers.IO) {
-                        if (pendentes.isEmpty()) {
+                        if (completion >= 0.8) {
                             NetworkModule.api.aprovarSolicitacao(solicitacao.id)
                         }
                     }

--- a/APPproducao/site/projetista/__init__.py
+++ b/APPproducao/site/projetista/__init__.py
@@ -266,7 +266,8 @@ def api_compras(id):
     sol = Solicitacao.query.get_or_404(id)
     dados = request.get_json() or {}
     pendencias = dados.get('pendencias', [])
-    sol.status = 'compras'
+    if sol.status != 'aprovado':
+        sol.status = 'compras'
     sol.pendencias = json.dumps(pendencias)
     db.session.commit()
     return jsonify({'ok': True})

--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistActivity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistActivity.kt
@@ -49,13 +49,19 @@ class ChecklistActivity : AppCompatActivity() {
         val btn = findViewById<Button>(R.id.btnConcluir)
         btn.setOnClickListener {
             val pendentes = solicitacao.itens.filterIndexed { index, _ -> !checks[index].isChecked }
+
+            // Calculate completion percentage
+            val checkedCount = checks.count { it.isChecked }
+            val completion = checkedCount.toDouble() / checks.size
+
             lifecycleScope.launch {
                 try {
                     withContext(Dispatchers.IO) {
-                        if (pendentes.isEmpty()) {
+                        if (completion >= 0.8) {
                             NetworkModule.api.aprovarSolicitacao(solicitacao.id)
                         }
                     }
+
                     if (pendentes.isEmpty()) {
                         setResult(Activity.RESULT_OK)
                         finish()

--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -266,7 +266,8 @@ def api_compras(id):
     sol = Solicitacao.query.get_or_404(id)
     dados = request.get_json() or {}
     pendencias = dados.get('pendencias', [])
-    sol.status = 'compras'
+    if sol.status != 'aprovado':
+        sol.status = 'compras'
     sol.pendencias = json.dumps(pendencias)
     db.session.commit()
     return jsonify({'ok': True})


### PR DESCRIPTION
## Summary
- approve checklist items only when at least 80% are marked done
- keep `aprovado` status when sending pending items in APPproducao server

## Testing
- `python3 -m py_compile site/*.py site/*/*.py APPproducao/site/*/*.py`
- `bash ./AppEstoque/gradlew --version` *(fails: Unable to tunnel through proxy)*
- `bash ./APPproducao/AppEstoque/gradlew --version` *(fails: Unable to tunnel through proxy)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_688ba7bfaf90832f96b6a53767d2ab67