### PR TITLE
Enforce 80% completion rule

### DIFF
--- a/APPproducao/site/projetista/__init__.py
+++ b/APPproducao/site/projetista/__init__.py
@@ -266,7 +266,12 @@ def api_compras(id):
     sol = Solicitacao.query.get_or_404(id)
     dados = request.get_json() or {}
     pendencias = dados.get('pendencias', [])
-    if sol.status != 'aprovado':
+    total = len(sol.itens)
+    concluido = total - len(pendencias)
+    porcentagem = concluido / total if total else 0
+    if porcentagem >= 0.8:
+        sol.status = 'aprovado'
+    elif sol.status != 'aprovado':
         sol.status = 'compras'
     sol.pendencias = json.dumps(pendencias)
     db.session.commit()

--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistActivity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistActivity.kt
@@ -50,12 +50,15 @@ class ChecklistActivity : AppCompatActivity() {
         btn.setOnClickListener {
             val pendentes = solicitacao.itens.filterIndexed { index, _ -> !checks[index].isChecked }
 
-
+            val checkedCount = checks.count { it.isChecked }
+            val completion = checkedCount.toDouble() / checks.size
 
             lifecycleScope.launch {
                 try {
                     withContext(Dispatchers.IO) {
-
+                        if (completion >= 0.8) {
+                            NetworkModule.api.aprovarSolicitacao(solicitacao.id)
+                        }
                     }
 
                     if (pendentes.isEmpty()) {

--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -266,7 +266,12 @@ def api_compras(id):
     sol = Solicitacao.query.get_or_404(id)
     dados = request.get_json() or {}
     pendencias = dados.get('pendencias', [])
-    if sol.status != 'aprovado':
+    total = len(sol.itens)
+    concluido = total - len(pendencias)
+    porcentagem = concluido / total if total else 0
+    if porcentagem >= 0.8:
+        sol.status = 'aprovado'
+    elif sol.status != 'aprovado':
         sol.status = 'compras'
     sol.pendencias = json.dumps(pendencias)
     db.session.commit()


### PR DESCRIPTION
## Summary
- compute completion percent in checklist activity and call the approval endpoint when >=80%
- apply the same rule when forwarding items to `compras`

## Testing
- `python3 -m py_compile site/*.py site/*/*.py APPproducao/site/*/*.py`
- `bash ./AppEstoque/gradlew --version` *(fails: Unable to tunnel through proxy)*
- `bash ./APPproducao/AppEstoque/gradlew --version` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688bb33cb0ec832f962922dadd9d085d