### PR TITLE
Stop auto approval when checklist incomplete

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistActivity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistActivity.kt
@@ -50,18 +50,12 @@ class ChecklistActivity : AppCompatActivity() {
         btn.setOnClickListener {
             val pendentes = solicitacao.itens.filterIndexed { index, _ -> !checks[index].isChecked }
 
-            val checkedCount = checks.count { it.isChecked }
-            val completion = checkedCount.toDouble() / checks.size
-
             lifecycleScope.launch {
                 try {
-                    withContext(Dispatchers.IO) {
-                        if (completion >= 0.8) {
+                    if (pendentes.isEmpty()) {
+                        withContext(Dispatchers.IO) {
                             NetworkModule.api.aprovarSolicitacao(solicitacao.id)
                         }
-                    }
-
-                    if (pendentes.isEmpty()) {
                         setResult(Activity.RESULT_OK)
                         finish()
                     } else {

--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -268,10 +268,10 @@ def api_compras(id):
     pendencias = dados.get('pendencias', [])
     total = len(sol.itens)
     concluido = total - len(pendencias)
-    porcentagem = concluido / total if total else 0
-    if porcentagem >= 0.8:
+
+    if not pendencias:
         sol.status = 'aprovado'
-    elif sol.status != 'aprovado':
+    else:
         sol.status = 'compras'
     sol.pendencias = json.dumps(pendencias)
     db.session.commit()


### PR DESCRIPTION
## Summary
- prevent auto approval in ChecklistActivity so remaining items always go to PendenciasActivity
- keep purchases status when sending pendências from the app

## Testing
- `python -m py_compile site/*.py`
- `./gradlew test` *(fails: unable to download gradle)*

------
https://chatgpt.com/codex/tasks/task_e_688bb82a8078832fae645abb3c5533bc