### PR TITLE
Implement 80 percent approval for checklist

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistActivity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistActivity.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.lifecycleScope
 import com.example.apestoque.R
 import com.example.apestoque.data.NetworkModule
 import com.example.apestoque.data.Solicitacao
+import com.example.apestoque.data.ComprasRequest
 import com.squareup.moshi.Types
 import com.example.apestoque.data.Item
 import com.squareup.moshi.Moshi
@@ -49,23 +50,38 @@ class ChecklistActivity : AppCompatActivity() {
         val btn = findViewById<Button>(R.id.btnConcluir)
         btn.setOnClickListener {
             val pendentes = solicitacao.itens.filterIndexed { index, _ -> !checks[index].isChecked }
+            val checkedCount = checks.count { it.isChecked }
+            val completion = checkedCount.toDouble() / checks.size
 
             lifecycleScope.launch {
                 try {
-                    if (pendentes.isEmpty()) {
-                        withContext(Dispatchers.IO) {
-                            NetworkModule.api.aprovarSolicitacao(solicitacao.id)
+                    when {
+                        pendentes.isEmpty() -> {
+                            withContext(Dispatchers.IO) {
+                                NetworkModule.api.aprovarSolicitacao(solicitacao.id)
+                            }
+                            setResult(Activity.RESULT_OK)
+                            finish()
                         }
-                        setResult(Activity.RESULT_OK)
-                        finish()
-                    } else {
-                        val jsonPend = moshi.adapter<List<Item>>(
-                            Types.newParameterizedType(List::class.java, Item::class.java)
-                        ).toJson(pendentes)
-                        val intent = Intent(this@ChecklistActivity, PendenciasActivity::class.java)
-                        intent.putExtra("id", solicitacao.id)
-                        intent.putExtra("pendencias", jsonPend)
-                        launcher.launch(intent)
+                        completion >= 0.8 -> {
+                            withContext(Dispatchers.IO) {
+                                NetworkModule.api.marcarCompras(
+                                    solicitacao.id,
+                                    ComprasRequest(pendentes)
+                                )
+                            }
+                            setResult(Activity.RESULT_OK)
+                            finish()
+                        }
+                        else -> {
+                            val jsonPend = moshi.adapter<List<Item>>(
+                                Types.newParameterizedType(List::class.java, Item::class.java)
+                            ).toJson(pendentes)
+                            val intent = Intent(this@ChecklistActivity, PendenciasActivity::class.java)
+                            intent.putExtra("id", solicitacao.id)
+                            intent.putExtra("pendencias", jsonPend)
+                            launcher.launch(intent)
+                        }
                     }
                 } catch (e: Exception) {
                     Toast.makeText(this@ChecklistActivity, "Erro ao enviar", Toast.LENGTH_SHORT).show()

--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -268,10 +268,11 @@ def api_compras(id):
     pendencias = dados.get('pendencias', [])
     total = len(sol.itens)
     concluido = total - len(pendencias)
+    porcentagem = concluido / total if total else 0
 
-    if not pendencias:
+    if porcentagem >= 0.8:
         sol.status = 'aprovado'
-    else:
+    elif sol.status != 'aprovado':
         sol.status = 'compras'
     sol.pendencias = json.dumps(pendencias)
     db.session.commit()


### PR DESCRIPTION
## Summary
- update `api_compras` to mark a solicitation as approved when 80% complete
- auto send checklist to compras when at least 80% checked in both app variants

## Testing
- `python3 -m py_compile site/projetista/__init__.py`
- `./gradlew test` *(fails: Unable to download gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_688bbb6382a8832f996b654c5bc54524