### PR TITLE
Enhance status display for partial completion

### DIFF
--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -25,6 +25,13 @@ def index():
             unicas.append(sol)
             vistas.add(sol.obra)
 
+    # prepara lista de pendências para exibição
+    for sol in unicas:
+        try:
+            sol.pendencias_list = json.loads(sol.pendencias or "[]")
+        except json.JSONDecodeError:
+            sol.pendencias_list = []
+
     return render_template('index.html', solicitacoes=unicas)
 
 @bp.route('/solicitacoes')
@@ -52,6 +59,12 @@ def solicitacoes():
 def iniciar_projeto():
     """Exibe os projetos divididos por status."""
     consulta = Solicitacao.query.order_by(Solicitacao.data.desc()).all()
+
+    for sol in consulta:
+        try:
+            sol.pendencias_list = json.loads(sol.pendencias or "[]")
+        except json.JSONDecodeError:
+            sol.pendencias_list = []
 
     analise = [s for s in consulta if s.status == 'analise']
     aprovado = [s for s in consulta if s.status == 'aprovado']

--- a/site/projetista/templates/index.html
+++ b/site/projetista/templates/index.html
@@ -27,8 +27,14 @@
         <td>
           {% if sol.status == 'analise' %}
             Em análise
-          {% elif sol.status == 'concluido' %}
-            Concluído
+          {% elif sol.status == 'aprovado' %}
+            {% if sol.pendencias_list %}
+              Material Separado com 80% da lista
+            {% else %}
+              Material separado completo
+            {% endif %}
+          {% elif sol.status == 'compras' %}
+            Pendente em compras
           {% else %}
             {{ sol.status }}
           {% endif %}
@@ -60,10 +66,15 @@
 
     select.addEventListener('change', applyFilter);
 
-    function renderStatus(status) {
+    function renderStatus(status, pendencias) {
+      if (status === 'aprovado') {
+        if (pendencias && pendencias !== '[]') {
+          return 'Material Separado com 80% da lista';
+        }
+        return 'Material separado completo';
+      }
       const map = {
         analise: 'Aguardando Andamento',
-        aprovado: 'Separado',
         compras: 'Pendente em compras',
       };
       return map[status] || status;
@@ -80,7 +91,7 @@
         tr.innerHTML = `
           <td>${sol.id}</td>
           <td>${sol.obra}</td>
-          <td>${renderStatus(sol.status)}</td>
+          <td>${renderStatus(sol.status, sol.pendencias)}</td>
           <td>
             <form method="post" action="/projetista/solicitacao/${sol.id}/delete" onsubmit="return confirm('Confirma apagar?');">
               <button type="submit" class="btn btn-sm btn-danger">Apagar</button>

--- a/site/projetista/templates/iniciar_projeto.html
+++ b/site/projetista/templates/iniciar_projeto.html
@@ -16,7 +16,14 @@
     <h4>Separado</h4>
     <ul class="list-group mb-4">
       {% for s in aprovado %}
-      <li class="list-group-item">#{{ s.id }} - {{ s.obra }}</li>
+      <li class="list-group-item">
+        #{{ s.id }} - {{ s.obra }}
+        {% if s.pendencias_list %}
+        <small class="d-block text-muted">Material Separado com 80% da lista</small>
+        {% else %}
+        <small class="d-block text-muted">Material separado completo</small>
+        {% endif %}
+      </li>
       {% else %}
       <li class="list-group-item text-muted">Nenhum projeto.</li>
       {% endfor %}


### PR DESCRIPTION
## Summary
- parse pending items for each request
- show partial vs full completion in index and project start pages
- update dynamic JS status rendering accordingly

## Testing
- `python3 -m py_compile site/app.py site/models.py site/projetista/__init__.py site/compras/__init__.py site/auth/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_688cf4d30e00832f81fdbadc012eaa20