### PR TITLE
Allow partially approved requests in compras

### DIFF
--- a/site/projetista/templates/compras.html
+++ b/site/projetista/templates/compras.html
@@ -216,7 +216,10 @@
       const resp = await fetch('/projetista/api/solicitacoes');
       if (!resp.ok) return;
       const data = await resp.json();
-      const compras = data.filter(sol => sol.status === 'compras');
+      const compras = data.filter(sol =>
+        sol.status === 'compras' ||
+        (sol.status === 'aprovado' && sol.pendencias && sol.pendencias !== '[]')
+      );
 
       const currentIds = compras.map(sol => sol.id);
       const newIds = currentIds.filter(id => !knownIds.has(id));


### PR DESCRIPTION
## Summary
- include approved requests with pending items in compras list
- update purchases template logic to show these requests

## Testing
- `python -m py_compile site/compras/__init__.py site/projetista/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_688cfb5518d8832fbe44fd15c7ae81f4