### PR TITLE
Add Aprovadas tab in AppProducao

### DIFF
--- a/APPproducao/app/src/main/java/com/example/appproducao/MainActivity.kt
+++ b/APPproducao/app/src/main/java/com/example/appproducao/MainActivity.kt
@@ -36,7 +36,7 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun MainScreen() {
     var selected by remember { mutableStateOf(0) }
-    val tabs = listOf("Iniciar", "Em produção")
+    val tabs = listOf("Aprovadas", "Em produção")
     Column {
         TabRow(selectedTabIndex = selected) {
             tabs.forEachIndexed { index, title ->
@@ -48,14 +48,14 @@ fun MainScreen() {
             }
         }
         when (selected) {
-            0 -> IniciarScreen()
+            0 -> AprovadasScreen()
             else -> EmProducaoScreen()
         }
     }
 }
 
 @Composable
-fun IniciarScreen() {
+fun AprovadasScreen() {
     var solicitacoes by remember { mutableStateOf<List<Solicitacao>>(emptyList()) }
     var error by remember { mutableStateOf<String?>(null) }
     var loading by remember { mutableStateOf(true) }
@@ -65,7 +65,7 @@ fun IniciarScreen() {
         scope.launch {
             try {
                 val all = NetworkModule.api.listarSolicitacoes()
-                solicitacoes = all.filter { it.status == "Separado" }
+                solicitacoes = all.filter { it.status == "aprovado" }
             } catch (e: Exception) {
                 error = e.localizedMessage
             } finally {


### PR DESCRIPTION
## Summary
- replace the "Iniciar" tab in AppProducao with a new "Aprovadas" tab
- copy logic from the Aprovado fragment in AppEstoque

## Testing
- `./APPproducao/gradlew -p APPproducao test` *(fails: Unable to download Gradle due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688d087cfd98832fb0d1310f1de99f0a