### PR TITLE
Fix placeholder text in Aprovadas tab

### DIFF
--- a/APPproducao/app/src/main/java/com/example/appproducao/MainActivity.kt
+++ b/APPproducao/app/src/main/java/com/example/appproducao/MainActivity.kt
@@ -87,7 +87,7 @@ fun AprovadasScreen() {
             LazyColumn {
                 items(solicitacoes) { sol ->
                     Text(
-                        text = "${'$'}{sol.obra} - id ${'$'}{sol.id}",
+                        text = "${sol.obra} - id ${sol.id}",
                         modifier = Modifier.padding(16.dp)
                     )
                     Divider()
@@ -141,7 +141,7 @@ fun EmProducaoScreen() {
                     }
                     items(lista80) { sol ->
                         Text(
-                            text = "${'$'}{sol.obra} - id ${'$'}{sol.id}",
+                            text = "${sol.obra} - id ${sol.id}",
                             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
                         )
                         Divider()
@@ -157,7 +157,7 @@ fun EmProducaoScreen() {
                     }
                     items(listaCompleta) { sol ->
                         Text(
-                            text = "${'$'}{sol.obra} - id ${'$'}{sol.id}",
+                            text = "${sol.obra} - id ${sol.id}",
                             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
                         )
                         Divider()


### PR DESCRIPTION
## Summary
- display obra and id values rather than raw placeholders in app

## Testing
- `./gradlew tasks --all` *(fails: Unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688d0c9a1590832fbc99eda2755e1ef7