### PR TITLE
Add subproject folder option for new solicitations

### DIFF
--- a/site/projetista/templates/nova_solicitacao.html
+++ b/site/projetista/templates/nova_solicitacao.html
@@ -10,6 +10,19 @@
             <input type="text" class="form-control" id="obra" name="obra" placeholder="Obra" required>
             <label for="obra">Número da Obra</label>
           </div>
+          <div class="form-floating mb-3">
+            <select class="form-select" id="ano" name="ano" required>
+              <option value="" disabled selected>Selecione o ano</option>
+              {% for ano in anos %}
+              <option value="{{ ano }}">{{ ano }}</option>
+              {% endfor %}
+            </select>
+            <label for="ano">Ano</label>
+          </div>
+          <div class="form-floating mb-3">
+            <input type="number" class="form-control" id="subpastas" name="subpastas" min="0" value="0" placeholder="Quantidade de subpastas">
+            <label for="subpastas">Quantidade de Subpastas</label>
+          </div>
           <div class="mb-4">
             <label class="form-label fw-semibold">Importar de Excel</label>
             <input class="form-control" type="file" name="xlsx_file" accept=".xls,.xlsx">


### PR DESCRIPTION
## Summary
- Correct electromechanical subfolder name
- Allow specifying how many subproject folders to create when saving a solicitation
- Expose subproject count field on the new solicitation form

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68909e2e3140832f9d4cb64e3510864e