### PR TITLE
Add Checklist Posto01 activity for PDF generation

### DIFF
--- a/AppEstoque/app/src/main/AndroidManifest.xml
+++ b/AppEstoque/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
         </activity>
         <activity android:name=".checklist.ChecklistActivity"/>
         <activity android:name=".checklist.PendenciasActivity"/>
+        <activity android:name=".checklist.ChecklistPosto01Activity"/>
     </application>
 
 </manifest>

--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistActivity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistActivity.kt
@@ -11,16 +11,12 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.example.apestoque.R
-import com.example.apestoque.data.NetworkModule
 import com.example.apestoque.data.Solicitacao
-import com.example.apestoque.data.ComprasRequest
 import com.squareup.moshi.Types
 import com.example.apestoque.data.Item
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 class ChecklistActivity : AppCompatActivity() {
     private val launcher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
@@ -57,21 +53,20 @@ class ChecklistActivity : AppCompatActivity() {
                 try {
                     when {
                         pendentes.isEmpty() -> {
-                            withContext(Dispatchers.IO) {
-                                NetworkModule.api.aprovarSolicitacao(solicitacao.id)
-                            }
-                            setResult(Activity.RESULT_OK)
-                            finish()
+                            val intent = Intent(this@ChecklistActivity, ChecklistPosto01Activity::class.java)
+                            intent.putExtra("id", solicitacao.id)
+                            intent.putExtra("obra", solicitacao.obra)
+                            launcher.launch(intent)
                         }
                         completion >= 0.8 -> {
-                            withContext(Dispatchers.IO) {
-                                NetworkModule.api.marcarCompras(
-                                    solicitacao.id,
-                                    ComprasRequest(pendentes)
-                                )
-                            }
-                            setResult(Activity.RESULT_OK)
-                            finish()
+                            val jsonPend = moshi.adapter<List<Item>>(
+                                Types.newParameterizedType(List::class.java, Item::class.java)
+                            ).toJson(pendentes)
+                            val intent = Intent(this@ChecklistActivity, ChecklistPosto01Activity::class.java)
+                            intent.putExtra("id", solicitacao.id)
+                            intent.putExtra("obra", solicitacao.obra)
+                            intent.putExtra("pendentes", jsonPend)
+                            launcher.launch(intent)
                         }
                         else -> {
                             val jsonPend = moshi.adapter<List<Item>>(

--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Activity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Activity.kt
@@ -1,0 +1,95 @@
+package com.example.apestoque.checklist
+
+import android.app.Activity
+import android.graphics.Paint
+import android.graphics.pdf.PdfDocument
+import android.os.Bundle
+import android.os.Environment
+import android.widget.Button
+import android.widget.CheckBox
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import com.example.apestoque.R
+import com.example.apestoque.data.ComprasRequest
+import com.example.apestoque.data.Item
+import com.example.apestoque.data.NetworkModule
+import com.squareup.moshi.Types
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+
+class ChecklistPosto01Activity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_checklist_posto01)
+
+        val id = intent.getIntExtra("id", -1)
+        if (id == -1) return finish()
+        val obra = intent.getStringExtra("obra") ?: ""
+        val jsonPend = intent.getStringExtra("pendentes")
+        val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+        val pendentes = jsonPend?.let {
+            val type = Types.newParameterizedType(List::class.java, Item::class.java)
+            moshi.adapter<List<Item>>(type).fromJson(it)
+        }
+
+        val cbC = findViewById<CheckBox>(R.id.cbC)
+        val cbNC = findViewById<CheckBox>(R.id.cbNC)
+
+        findViewById<Button>(R.id.btnConcluirPosto01).setOnClickListener {
+            val isC = cbC.isChecked
+            val isNC = cbNC.isChecked
+            if (!isC && !isNC) {
+                Toast.makeText(this, "Selecione uma opção", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+
+            lifecycleScope.launch {
+                try {
+                    gerarPdf(obra, isC)
+                    withContext(Dispatchers.IO) {
+                        if (pendentes == null) {
+                            NetworkModule.api.aprovarSolicitacao(id)
+                        } else {
+                            NetworkModule.api.marcarCompras(id, ComprasRequest(pendentes))
+                        }
+                    }
+                    setResult(Activity.RESULT_OK)
+                    finish()
+                } catch (e: Exception) {
+                    Toast.makeText(this@ChecklistPosto01Activity, "Erro ao concluir", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    private fun gerarPdf(obra: String, marcadoC: Boolean) {
+        val pdf = PdfDocument()
+        val pageInfo = PdfDocument.PageInfo.Builder(595, 842, 1).create()
+        val page = pdf.startPage(pageInfo)
+        val canvas = page.canvas
+        val paint = Paint()
+        paint.textSize = 12f
+        val xC = 94.78f
+        val yC = 125.4f
+        val xNC = 94.78f
+        val yNC = 125.4f
+        val x = if (marcadoC) xC else xNC
+        val y = if (marcadoC) yC else yNC
+        canvas.drawText("X", x, y, paint)
+        pdf.finishPage(page)
+
+        val dirDocs = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS)
+        val dir = File(dirDocs, "$obra/CHECKLIST")
+        dir.mkdirs()
+        val file = File(dir, "checklist_posto01.pdf")
+        FileOutputStream(file).use { fos -> pdf.writeTo(fos) }
+        pdf.close()
+    }
+}
+

--- a/AppEstoque/app/src/main/res/layout/activity_checklist_posto01.xml
+++ b/AppEstoque/app/src/main/res/layout/activity_checklist_posto01.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="1.1 COMPONENTES: Identificação do projeto"
+            android:textSize="18sp"
+            android:layout_marginBottom="16dp"/>
+
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+
+            <CheckBox
+                android:id="@+id/cbC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="C"/>
+
+            <CheckBox
+                android:id="@+id/cbNC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.C"
+                android:layout_marginStart="24dp"/>
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/btnConcluirPosto01"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Concluir"
+            android:layout_marginTop="24dp"/>
+
+    </LinearLayout>
+</ScrollView>


### PR DESCRIPTION
## Summary
- launch Checklist Posto01 screen when checklist is complete or 80% done
- add UI to mark C or N.C and generate PDF with coordinates
- register new activity in manifest

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden" *)

------
https://chatgpt.com/codex/tasks/task_e_6890ae6405f0832f8c85584aa3613faa