### PR TITLE
Load checklist PDF template from assets

### DIFF
--- a/AppEstoque/app/src/main/assets/checklist_posto01_template.pdf
+++ b/AppEstoque/app/src/main/assets/checklist_posto01_template.pdf
@@ -1,0 +1,14 @@
+%PDF-1.4
+1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
+2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] >> endobj
+xref
+0 4
+0000000000 65535 f 
+0000000010 00000 n 
+0000000053 00000 n 
+0000000104 00000 n 
+trailer << /Size 4 /Root 1 0 R >>
+startxref
+155
+%%EOF

--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Activity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Activity.kt
@@ -1,10 +1,13 @@
 package com.example.apestoque.checklist
 
 import android.app.Activity
+import android.graphics.Bitmap
 import android.graphics.Paint
 import android.graphics.pdf.PdfDocument
+import android.graphics.pdf.PdfRenderer
 import android.os.Bundle
 import android.os.Environment
+import android.os.ParcelFileDescriptor
 import android.widget.Button
 import android.widget.CheckBox
 import android.widget.Toast
@@ -77,19 +80,42 @@ class ChecklistPosto01Activity : AppCompatActivity() {
     }
 
     private fun gerarPdf(obra: String, marcadoC: Boolean) {
+        // Carrega o template a partir dos assets
+        val templateName = "checklist_posto01_template.pdf"
+        val tempFile = File.createTempFile("template", ".pdf", cacheDir)
+        assets.open(templateName).use { input ->
+            FileOutputStream(tempFile).use { output ->
+                input.copyTo(output)
+            }
+        }
+
+        val renderer = PdfRenderer(
+            ParcelFileDescriptor.open(tempFile, ParcelFileDescriptor.MODE_READ_ONLY)
+        )
+        val templatePage = renderer.openPage(0)
+
         val pdf = PdfDocument()
-        val pageInfo = PdfDocument.PageInfo.Builder(595, 842, 1).create()
+        val pageInfo = PdfDocument.PageInfo.Builder(templatePage.width, templatePage.height, 1).create()
         val page = pdf.startPage(pageInfo)
         val canvas = page.canvas
+
+        // desenha o template na nova página
+        val bitmap = Bitmap.createBitmap(templatePage.width, templatePage.height, Bitmap.Config.ARGB_8888)
+        templatePage.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_PRINT)
+        canvas.drawBitmap(bitmap, 0f, 0f, null)
+
         val paint = Paint().apply { textSize = 12f }
         val xC = 94.78f
         val yC = 125.4f
         val xNC = 150.78f
         val yNC = 125.4f
-        val x = if (marcadoC) xC else xNC
-        val y = if (marcadoC) yC else yNC
+        val (x, y) = if (marcadoC) xC to yC else xNC to yNC
         canvas.drawText("X", x, y, paint)
+
         pdf.finishPage(page)
+        templatePage.close()
+        renderer.close()
+        tempFile.delete()
 
         val ano = Calendar.getInstance().get(Calendar.YEAR)
         val base = File(


### PR DESCRIPTION
## Summary
- add PDF template under `assets`
- generate checklist PDF by loading template from assets and marking selection

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6890ba52ab54832f88b1b1b922f0be7d