### PR TITLE
Load checklist PDF template from assets

### DIFF
--- a/AppEstoque/app/src/main/assets/checklistttt.pdf
+++ b/AppEstoque/app/src/main/assets/checklistttt.pdf
@@ -1,0 +1,14 @@
+%PDF-1.4
+1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
+2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] >> endobj
+xref
+0 4
+0000000000 65535 f 
+0000000010 00000 n 
+0000000053 00000 n 
+0000000104 00000 n 
+trailer << /Size 4 /Root 1 0 R >>
+startxref
+155
+%%EOF


### PR DESCRIPTION
## Summary
- add PDF template under `assets`
- generate checklist PDF by loading template from assets and marking selection
- save generated checklist PDF to app-specific Documents directory to avoid storage permission errors

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6890ba52ab54832f88b1b1b922f0be7d