### PR TITLE
Listar obras por ano ao criar solicitação

### DIFF
--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -96,13 +96,23 @@ def iniciar_projeto():
 @bp.route('/solicitacao/nova', methods=['GET', 'POST'])
 @login_required
 def nova_solicitacao():
-    # tenta descobrir os anos disponíveis no servidor
+    # tenta descobrir os anos e obras disponíveis no servidor
     try:
         anos = [d for d in os.listdir(BASE_PRODUCAO)
                 if os.path.isdir(os.path.join(BASE_PRODUCAO, d))]
+        anos.sort()
+        obras_por_ano = {}
+        for ano in anos:
+            ano_dir = os.path.join(BASE_PRODUCAO, ano)
+            obras = [d for d in os.listdir(ano_dir)
+                     if os.path.isdir(os.path.join(ano_dir, d))]
+            obras.sort()
+            obras_por_ano[ano] = obras
     except OSError:
         # se o diretório não estiver acessível, usa o ano atual
-        anos = [str(datetime.now().year)]
+        ano_atual = str(datetime.now().year)
+        anos = [ano_atual]
+        obras_por_ano = {ano_atual: []}
 
     if request.method == 'POST':
         obra = request.form['obra'].strip()
@@ -164,7 +174,7 @@ def nova_solicitacao():
         flash('Solicitação criada com sucesso!', 'success')
         return redirect(url_for('projetista.solicitacoes'))
 
-    return render_template('nova_solicitacao.html', anos=anos)
+    return render_template('nova_solicitacao.html', anos=anos, obras_por_ano=obras_por_ano)
 
 
 @bp.route('/subpastas', methods=['GET', 'POST'])

--- a/site/projetista/templates/nova_solicitacao.html
+++ b/site/projetista/templates/nova_solicitacao.html
@@ -7,11 +7,6 @@
         <h2 class="card-title mb-4 text-center">Nova Solicitação</h2>
         <form method="post" enctype="multipart/form-data">
           <div class="form-floating mb-3">
-            <input type="text" class="form-control" id="obra" name="obra" placeholder="Obra" required>
-            <label for="obra">Número da Obra</label>
-          </div>
-          
-          <div class="form-floating mb-3">
             <select class="form-select" id="ano" name="ano" required>
               <option value="" disabled selected>Selecione o ano</option>
               {% for ano in anos %}
@@ -19,6 +14,12 @@
               {% endfor %}
             </select>
             <label for="ano">Ano</label>
+          </div>
+
+          <div class="form-floating mb-3">
+            <input list="obras_lista" class="form-control" id="obra" name="obra" placeholder="Obra" required>
+            <label for="obra">Número da Obra</label>
+            <datalist id="obras_lista"></datalist>
           </div>
 
           <div class="mb-4">
@@ -52,4 +53,21 @@
     </div>
   </div>
 </div>
+<script>
+const obrasPorAno = {{ obras_por_ano | tojson }};
+const anoSelect = document.getElementById('ano');
+const obrasDatalist = document.getElementById('obras_lista');
+
+function atualizarObras() {
+  const ano = anoSelect.value;
+  obrasDatalist.innerHTML = '';
+  (obrasPorAno[ano] || []).forEach(function(obra) {
+    const option = document.createElement('option');
+    option.value = obra;
+    obrasDatalist.appendChild(option);
+  });
+}
+
+anoSelect.addEventListener('change', atualizarObras);
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Popular lista de obras a partir das pastas do servidor, agrupadas por ano.
- Reordenar formulário da nova solicitação para selecionar o ano antes do número da obra e sugerir obras existentes.
- Manter criação automática das pastas da obra com subpastas padrão.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892183c9034832fbc3f3a7c15142b00