### PR TITLE
Use server path from checklist save response

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Activity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Activity.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.widget.Button
 import android.widget.CheckBox
 import android.widget.Toast
-import java.util.Calendar
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.example.apestoque.R
@@ -59,14 +58,13 @@ class ChecklistPosto01Activity : AppCompatActivity() {
                     val filePath = withContext(Dispatchers.IO) {
                         val type = Types.newParameterizedType(List::class.java, String::class.java)
                         val json = moshi.adapter<List<String>>(type).toJson(marcados)
-                        val ano = Calendar.getInstance().get(Calendar.YEAR)
-                        NetworkModule.api.salvarChecklist(id, ChecklistRequest(obra, json))
+                        val response = NetworkModule.api.salvarChecklist(id, ChecklistRequest(obra, json))
                         if (pendentes == null) {
                             NetworkModule.api.aprovarSolicitacao(id)
                         } else {
                             NetworkModule.api.marcarCompras(id, ComprasRequest(pendentes))
                         }
-                        "ENGENHARIA/03 - PRODUCAO/$ano/$obra/CHECKLIST/checklist_posto01.json"
+                        response.caminho
                     }
                     Toast.makeText(
                         this@ChecklistPosto01Activity,

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/ApiService.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/ApiService.kt
@@ -22,5 +22,5 @@ interface ApiService {
     suspend fun salvarChecklist(
         @Path("id") id: Int,
         @Body body: ChecklistRequest
-    )
+    ): ChecklistResponse
 }

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/ChecklistResponse.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/ChecklistResponse.kt
@@ -1,0 +1,8 @@
+package com.example.apestoque.data
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class ChecklistResponse(
+    val caminho: String
+)


### PR DESCRIPTION
## Summary
- return saved file path from API `salvarChecklist`
- show checklist file path returned by server

## Testing
- `sh gradlew test` *(fails: Unable to tunnel through proxy HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68923e033748832fb0d759105f27b073