### PR TITLE
Save checklist to local server

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Activity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Activity.kt
@@ -12,6 +12,7 @@ import com.example.apestoque.data.ChecklistRequest
 import com.example.apestoque.data.ComprasRequest
 import com.example.apestoque.data.Item
 import com.example.apestoque.data.NetworkModule
+import com.example.apestoque.data.JsonNetworkModule
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
@@ -58,7 +59,7 @@ class ChecklistPosto01Activity : AppCompatActivity() {
                     val filePath = withContext(Dispatchers.IO) {
                         val type = Types.newParameterizedType(List::class.java, String::class.java)
                         val json = moshi.adapter<List<String>>(type).toJson(marcados)
-                        val response = NetworkModule.api.salvarChecklist(id, ChecklistRequest(obra, json))
+                        val response = JsonNetworkModule.api.salvarChecklist(ChecklistRequest(obra, json))
                         if (pendentes == null) {
                             NetworkModule.api.aprovarSolicitacao(id)
                         } else {

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/ApiService.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/ApiService.kt
@@ -18,9 +18,4 @@ interface ApiService {
         @Body body: ComprasRequest
     )
 
-    @POST("api/solicitacoes/{id}/checklist")
-    suspend fun salvarChecklist(
-        @Path("id") id: Int,
-        @Body body: ChecklistRequest
-    ): ChecklistResponse
 }

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/JsonApiService.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/JsonApiService.kt
@@ -1,0 +1,11 @@
+package com.example.apestoque.data
+
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface JsonApiService {
+    @POST("checklist")
+    suspend fun salvarChecklist(
+        @Body body: ChecklistRequest
+    ): ChecklistResponse
+}

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/JsonNetworkModule.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/JsonNetworkModule.kt
@@ -1,0 +1,19 @@
+package com.example.apestoque.data
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+object JsonNetworkModule {
+    private val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+
+    private val retrofit = Retrofit.Builder()
+        .baseUrl("http://192.168.0.135:5000/json_api/")
+        .addConverterFactory(MoshiConverterFactory.create(moshi))
+        .build()
+
+    val api: JsonApiService = retrofit.create(JsonApiService::class.java)
+}

--- a/site/app.py
+++ b/site/app.py
@@ -5,6 +5,7 @@ from models import db, User, AuthorizedIP, ITEM_STATUS_OPTIONS
 from projetista import bp as projetista_bp
 from compras import bp as compras_bp
 from auth import bp as auth_bp
+from json_api import bp as json_api_bp
 from flask_login import LoginManager, login_user, current_user
 from flask import Flask, request
 from sqlalchemy import inspect
@@ -44,6 +45,7 @@ def create_app():
 
     app.register_blueprint(projetista_bp, url_prefix='/projetista')
     app.register_blueprint(compras_bp, url_prefix='/compras')
+    app.register_blueprint(json_api_bp, url_prefix='/json_api')
     app.register_blueprint(auth_bp)
 
 

--- a/site/json_api/__init__.py
+++ b/site/json_api/__init__.py
@@ -1,0 +1,29 @@
+from flask import Blueprint, request, jsonify
+import os
+import json
+from datetime import datetime
+
+bp = Blueprint('json_api', __name__)
+
+BASE_DIR = os.path.dirname(__file__)
+
+@bp.route('/checklist', methods=['POST'])
+def salvar_checklist():
+    data = request.get_json() or {}
+    obra = data.get('obra', 'desconhecida')
+    conteudo = data.get('conteudo', '[]')
+    try:
+        conteudo_json = json.loads(conteudo)
+    except json.JSONDecodeError:
+        conteudo_json = conteudo
+
+    os.makedirs(BASE_DIR, exist_ok=True)
+    timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
+    safe_obra = "".join(c for c in obra if c.isalnum() or c in ('-','_')) or 'obra'
+    filename = f"checklist_{safe_obra}_{timestamp}.json"
+    file_path = os.path.join(BASE_DIR, filename)
+
+    with open(file_path, 'w', encoding='utf-8') as f:
+        json.dump({"obra": obra, "conteudo": conteudo_json}, f, ensure_ascii=False, indent=2)
+
+    return jsonify({'caminho': file_path})


### PR DESCRIPTION
## Summary
- add API endpoint to store checklist JSON files on the server
- send checklist selections from Android to the new Flask endpoint

## Testing
- `python -m py_compile site/json_api/__init__.py site/app.py site/projetista/__init__.py`
- `bash gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689244b79a1c832f948640aa4fc60f64