### PR TITLE
Handle repository errors with Result and add tests

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Activity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Activity.kt
@@ -89,3 +89,4 @@ class ChecklistPosto01Activity : AppCompatActivity() {
             }
         }
     }
+}

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/SolicitacaoRepository.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/SolicitacaoRepository.kt
@@ -1,12 +1,12 @@
 package com.example.apestoque.data
 
 class SolicitacaoRepository(private val api: ApiService) {
-    suspend fun fetchSolicitacoes(): List<Solicitacao> =
-        api.listarSolicitacoes()
+    suspend fun fetchSolicitacoes(): Result<List<Solicitacao>> =
+        runCatching { api.listarSolicitacoes() }
 
-    suspend fun aprovarSolicitacao(id: Int) =
-        api.aprovarSolicitacao(id)
+    suspend fun aprovarSolicitacao(id: Int): Result<Unit> =
+        runCatching { api.aprovarSolicitacao(id) }
 
-    suspend fun marcarCompras(id: Int, body: ComprasRequest) =
-        api.marcarCompras(id, body)
+    suspend fun marcarCompras(id: Int, body: ComprasRequest): Result<Unit> =
+        runCatching { api.marcarCompras(id, body) }
 }

--- a/AppEstoque/app/src/main/java/com/example/apestoque/ui/theme/SolicitacaoViewModel.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/ui/theme/SolicitacaoViewModel.kt
@@ -17,12 +17,7 @@ class SolicitacaoViewModel : ViewModel() {
 
     init {
         viewModelScope.launch {
-            try {
-                _lista.value = repo.fetchSolicitacoes()
-            } catch (e: Exception) {
-                // Trate erro aqui, ex.: log ou estado de erro
-                _lista.value = emptyList()
-            }
+            _lista.value = repo.fetchSolicitacoes().getOrElse { emptyList() }
         }
     }
 }

--- a/AppEstoque/app/src/test/java/com/example/apestoque/SolicitacaoRepositoryTest.kt
+++ b/AppEstoque/app/src/test/java/com/example/apestoque/SolicitacaoRepositoryTest.kt
@@ -1,0 +1,49 @@
+package com.example.apestoque
+
+import com.example.apestoque.data.*
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Test
+import java.io.IOException
+
+class FakeApiService : ApiService {
+    var shouldThrow = false
+    override suspend fun listarSolicitacoes(): List<Solicitacao> {
+        if (shouldThrow) throw IOException("network")
+        return listOf(
+            Solicitacao(
+                id = 1,
+                obra = "Obra 1",
+                data = "2024-01-01",
+                itens = listOf(Item("Ref", 2))
+            )
+        )
+    }
+
+    override suspend fun aprovarSolicitacao(id: Int) {
+        if (shouldThrow) throw IOException("network")
+    }
+
+    override suspend fun marcarCompras(id: Int, body: ComprasRequest) {
+        if (shouldThrow) throw IOException("network")
+    }
+}
+
+class SolicitacaoRepositoryTest {
+    private val api = FakeApiService()
+    private val repo = SolicitacaoRepository(api)
+
+    @Test
+    fun fetchSolicitacoes_returnsDataOnSuccess() = runBlocking {
+        val result = repo.fetchSolicitacoes()
+        assertTrue(result.isSuccess)
+        assertEquals(1, result.getOrThrow().size)
+    }
+
+    @Test
+    fun fetchSolicitacoes_returnsFailureOnException() = runBlocking {
+        api.shouldThrow = true
+        val result = repo.fetchSolicitacoes()
+        assertTrue(result.isFailure)
+    }
+}


### PR DESCRIPTION
## Summary
- Wrap API interactions in `SolicitacaoRepository` with `Result` for safer error handling
- Simplify `SolicitacaoViewModel` initialization using `Result`
- Add unit tests verifying repository success and failure behavior
- Fix missing closing brace in `ChecklistPosto01Activity`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68925289c0f0832fb482c2cfbcae454a