### PR TITLE
Add second checklist step for Posto01

### DIFF
--- a/AppEstoque/app/src/main/AndroidManifest.xml
+++ b/AppEstoque/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
         <activity android:name=".checklist.ChecklistActivity"/>
         <activity android:name=".checklist.PendenciasActivity"/>
         <activity android:name=".checklist.ChecklistPosto01Activity"/>
+        <activity android:name=".checklist.ChecklistPosto01Parte2Activity"/>
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Parte2Activity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Parte2Activity.kt
@@ -1,0 +1,142 @@
+package com.example.apestoque.checklist
+
+import android.app.Activity
+import android.os.Bundle
+import android.widget.Button
+import android.widget.CheckBox
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import com.example.apestoque.R
+import com.example.apestoque.data.ChecklistItem
+import com.example.apestoque.data.ChecklistRequest
+import com.example.apestoque.data.ComprasRequest
+import com.example.apestoque.data.Item
+import com.example.apestoque.data.NetworkModule
+import com.example.apestoque.data.JsonNetworkModule
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.util.Calendar
+
+class ChecklistPosto01Parte2Activity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_checklist_posto01_parte2)
+
+        val id = intent.getIntExtra("id", -1)
+        if (id == -1) return finish()
+        val jsonPend = intent.getStringExtra("pendentes")
+        val obra = intent.getStringExtra("obra") ?: ""
+        val prevJson = intent.getStringExtra("itens") ?: "[]"
+
+        val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+        val pendentes = jsonPend?.let {
+            val type = Types.newParameterizedType(List::class.java, Item::class.java)
+            moshi.adapter<List<Item>>(type).fromJson(it)
+        }
+        val checklistType = Types.newParameterizedType(List::class.java, ChecklistItem::class.java)
+        val prevItems = moshi.adapter<List<ChecklistItem>>(checklistType).fromJson(prevJson) ?: emptyList()
+
+        val pairs = listOf(
+            R.id.cbQ55C to R.id.cbQ55NC,
+            R.id.cbQ56C to R.id.cbQ56NC,
+            R.id.cbQ57C to R.id.cbQ57NC,
+            R.id.cbQ58C to R.id.cbQ58NC,
+            R.id.cbQ59C to R.id.cbQ59NC,
+            R.id.cbQ60C to R.id.cbQ60NC,
+            R.id.cbQ61C to R.id.cbQ61NC,
+            R.id.cbQ62C to R.id.cbQ62NC,
+            R.id.cbQ63C to R.id.cbQ63NC,
+            R.id.cbQ64C to R.id.cbQ64NC,
+            R.id.cbQ65C to R.id.cbQ65NC,
+            R.id.cbQ66C to R.id.cbQ66NC,
+            R.id.cbQ67C to R.id.cbQ67NC,
+            R.id.cbQ68C to R.id.cbQ68NC,
+            R.id.cbQ69C to R.id.cbQ69NC,
+            R.id.cbQ70C to R.id.cbQ70NC,
+            R.id.cbQ71C to R.id.cbQ71NC,
+            R.id.cbQ72C to R.id.cbQ72NC,
+            R.id.cbQ73C to R.id.cbQ73NC,
+            R.id.cbQ74C to R.id.cbQ74NC,
+        ).map { (c, nc) -> findViewById<CheckBox>(c) to findViewById<CheckBox>(nc) }
+
+        pairs.forEach { (cbC, cbNC) ->
+            cbC.setOnCheckedChangeListener { _, isChecked -> if (isChecked) cbNC.isChecked = false }
+            cbNC.setOnCheckedChangeListener { _, isChecked -> if (isChecked) cbC.isChecked = false }
+        }
+
+        val questions = listOf(
+            "1.1 - COMPONENTES: Identificação do projeto",
+            "1.1 - COMPONENTES: Separação - POSTO - 01",
+            "1.1 - COMPONENTES: Referências x Projeto",
+            "1.1 - COMPONENTES: Material em bom estado",
+            "1.7 - INVÓLUCRO - PORTAS SEM RECORTE: Identificação do projeto",
+            "1.7 - INVÓLUCRO - PORTAS SEM RECORTE: Separação - POSTO - 07",
+            "1.7 - INVÓLUCRO - PORTAS SEM RECORTE: Referências x Projeto",
+            "1.7 - INVÓLUCRO - PORTAS SEM RECORTE: Material em bom estado",
+            "1.9 - INVÓLUCRO - CONTRAPORTAS SEM RECORTE: Identificação do projeto",
+            "1.9 - INVÓLUCRO - CONTRAPORTAS SEM RECORTE: Separação - POSTO - 07",
+            "1.9 - INVÓLUCRO - CONTRAPORTAS SEM RECORTE: Referências x Projeto",
+            "1.9 - INVÓLUCRO - CONTRAPORTAS SEM RECORTE: Material em bom estado",
+            "1.10 - INVÓLUCRO - FECHAMENTOS LATERAIS E TRASEIRO: Identificação do projeto",
+            "1.10 - INVÓLUCRO - FECHAMENTOS LATERAIS E TRASEIRO: Separação - POSTO - 07",
+            "1.10 - INVÓLUCRO - FECHAMENTOS LATERAIS E TRASEIRO: Referências x Projeto",
+            "1.10 - INVÓLUCRO - FECHAMENTOS LATERAIS E TRASEIRO: Material em bom estado",
+            "1.15 - POLICARBONATO: Identificação do projeto",
+            "1.15 - POLICARBONATO: Separação - POSTO - 03",
+            "1.15 - POLICARBONATO: Referências x Projeto",
+            "1.15 - POLICARBONATO: Material em bom estado",
+        )
+
+        findViewById<Button>(R.id.btnConcluirPosto01Parte2).setOnClickListener {
+            val respostas = pairs.mapIndexed { index, (cbC, cbNC) ->
+                val marcados = mutableListOf<String>()
+                if (cbC.isChecked) marcados.add("C")
+                if (cbNC.isChecked) marcados.add("NC")
+                if (marcados.isEmpty()) {
+                    Toast.makeText(this, "Selecione uma opção em: ${questions[index]}", Toast.LENGTH_SHORT).show()
+                    return@setOnClickListener
+                }
+                marcados
+            }
+
+            val itensChecklist = prevItems + questions.indices.map { i ->
+                ChecklistItem(questions[i], respostas[i])
+            }
+
+            val ano = Calendar.getInstance().get(Calendar.YEAR).toString()
+
+            lifecycleScope.launch {
+                try {
+                    val filePath = withContext(Dispatchers.IO) {
+                        val request = ChecklistRequest(obra, ano, itensChecklist)
+                        val response = JsonNetworkModule.api.salvarChecklist(request)
+                        if (pendentes == null) {
+                            NetworkModule.api.aprovarSolicitacao(id)
+                        } else {
+                            NetworkModule.api.marcarCompras(id, ComprasRequest(pendentes))
+                        }
+                        response.caminho
+                    }
+                    Toast.makeText(
+                        this@ChecklistPosto01Parte2Activity,
+                        "Checklist concluído. Arquivo salvo em:\n$filePath",
+                        Toast.LENGTH_LONG,
+                    ).show()
+                    setResult(Activity.RESULT_OK)
+                    finish()
+                } catch (e: Exception) {
+                    Toast.makeText(
+                        this@ChecklistPosto01Parte2Activity,
+                        "Erro ao concluir",
+                        Toast.LENGTH_SHORT,
+                    ).show()
+                }
+            }
+        }
+    }
+}

--- a/AppEstoque/app/src/main/res/layout/activity_checklist_posto01_parte2.xml
+++ b/AppEstoque/app/src/main/res/layout/activity_checklist_posto01_parte2.xml
@@ -1,0 +1,499 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <!-- 1.1 - COMPONENTES -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="1.1 - COMPONENTES"
+            android:textSize="18sp"
+            android:layout_marginBottom="16dp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Identificação do projeto" />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <CheckBox
+                android:id="@+id/cbQ55C"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="C" />
+            <CheckBox
+                android:id="@+id/cbQ55NC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.C"
+                android:layout_marginStart="24dp" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Separação - POSTO - 01"
+            android:layout_marginTop="8dp" />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <CheckBox
+                android:id="@+id/cbQ56C"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="C" />
+            <CheckBox
+                android:id="@+id/cbQ56NC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.C"
+                android:layout_marginStart="24dp" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Referências x Projeto"
+            android:layout_marginTop="8dp" />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <CheckBox
+                android:id="@+id/cbQ57C"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="C" />
+            <CheckBox
+                android:id="@+id/cbQ57NC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.C"
+                android:layout_marginStart="24dp" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Material em bom estado"
+            android:layout_marginTop="8dp" />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <CheckBox
+                android:id="@+id/cbQ58C"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="C" />
+            <CheckBox
+                android:id="@+id/cbQ58NC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.C"
+                android:layout_marginStart="24dp" />
+        </LinearLayout>
+
+        <!-- 1.7 - INVÓLUCRO - PORTAS SEM RECORTE -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="1.7 - INVÓLUCRO - PORTAS SEM RECORTE"
+            android:textSize="18sp"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Identificação do projeto" />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <CheckBox
+                android:id="@+id/cbQ59C"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="C" />
+            <CheckBox
+                android:id="@+id/cbQ59NC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.C"
+                android:layout_marginStart="24dp" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Separação - POSTO - 07"
+            android:layout_marginTop="8dp" />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <CheckBox
+                android:id="@+id/cbQ60C"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="C" />
+            <CheckBox
+                android:id="@+id/cbQ60NC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.C"
+                android:layout_marginStart="24dp" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Referências x Projeto"
+            android:layout_marginTop="8dp" />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <CheckBox
+                android:id="@+id/cbQ61C"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="C" />
+            <CheckBox
+                android:id="@+id/cbQ61NC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.C"
+                android:layout_marginStart="24dp" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Material em bom estado"
+            android:layout_marginTop="8dp" />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <CheckBox
+                android:id="@+id/cbQ62C"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="C" />
+            <CheckBox
+                android:id="@+id/cbQ62NC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.C"
+                android:layout_marginStart="24dp" />
+        </LinearLayout>
+
+        <!-- 1.9 - INVÓLUCRO - CONTRAPORTAS SEM RECORTE -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="1.9 - INVÓLUCRO - CONTRAPORTAS SEM RECORTE"
+            android:textSize="18sp"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Identificação do projeto" />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <CheckBox
+                android:id="@+id/cbQ63C"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="C" />
+            <CheckBox
+                android:id="@+id/cbQ63NC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.C"
+                android:layout_marginStart="24dp" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Separação - POSTO - 07"
+            android:layout_marginTop="8dp" />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <CheckBox
+                android:id="@+id/cbQ64C"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="C" />
+            <CheckBox
+                android:id="@+id/cbQ64NC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.C"
+                android:layout_marginStart="24dp" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Referências x Projeto"
+            android:layout_marginTop="8dp" />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <CheckBox
+                android:id="@+id/cbQ65C"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="C" />
+            <CheckBox
+                android:id="@+id/cbQ65NC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.C"
+                android:layout_marginStart="24dp" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Material em bom estado"
+            android:layout_marginTop="8dp" />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <CheckBox
+                android:id="@+id/cbQ66C"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="C" />
+            <CheckBox
+                android:id="@+id/cbQ66NC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.C"
+                android:layout_marginStart="24dp" />
+        </LinearLayout>
+
+        <!-- 1.10 - INVÓLUCRO - FECHAMENTOS LATERAIS E TRASEIRO -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="1.10 - INVÓLUCRO - FECHAMENTOS LATERAIS E TRASEIRO"
+            android:textSize="18sp"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Identificação do projeto" />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <CheckBox
+                android:id="@+id/cbQ67C"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="C" />
+            <CheckBox
+                android:id="@+id/cbQ67NC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.C"
+                android:layout_marginStart="24dp" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Separação - POSTO - 07"
+            android:layout_marginTop="8dp" />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <CheckBox
+                android:id="@+id/cbQ68C"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="C" />
+            <CheckBox
+                android:id="@+id/cbQ68NC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.C"
+                android:layout_marginStart="24dp" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Referências x Projeto"
+            android:layout_marginTop="8dp" />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <CheckBox
+                android:id="@+id/cbQ69C"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="C" />
+            <CheckBox
+                android:id="@+id/cbQ69NC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.C"
+                android:layout_marginStart="24dp" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Material em bom estado"
+            android:layout_marginTop="8dp" />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <CheckBox
+                android:id="@+id/cbQ70C"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="C" />
+            <CheckBox
+                android:id="@+id/cbQ70NC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.C"
+                android:layout_marginStart="24dp" />
+        </LinearLayout>
+
+        <!-- 1.15 - POLICARBONATO -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="1.15 - POLICARBONATO"
+            android:textSize="18sp"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Identificação do projeto" />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <CheckBox
+                android:id="@+id/cbQ71C"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="C" />
+            <CheckBox
+                android:id="@+id/cbQ71NC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.C"
+                android:layout_marginStart="24dp" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Separação - POSTO - 03"
+            android:layout_marginTop="8dp" />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <CheckBox
+                android:id="@+id/cbQ72C"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="C" />
+            <CheckBox
+                android:id="@+id/cbQ72NC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.C"
+                android:layout_marginStart="24dp" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Referências x Projeto"
+            android:layout_marginTop="8dp" />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <CheckBox
+                android:id="@+id/cbQ73C"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="C" />
+            <CheckBox
+                android:id="@+id/cbQ73NC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.C"
+                android:layout_marginStart="24dp" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Material em bom estado"
+            android:layout_marginTop="8dp" />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <CheckBox
+                android:id="@+id/cbQ74C"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="C" />
+            <CheckBox
+                android:id="@+id/cbQ74NC"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.C"
+                android:layout_marginStart="24dp" />
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/btnConcluirPosto01Parte2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Concluir"
+            android:layout_marginTop="16dp" />
+
+    </LinearLayout>
+</ScrollView>


### PR DESCRIPTION
## Summary
- split Posto01 checklist into two steps
- add second activity and layout with extra sections and submit JSON
- open second step when finishing first checklist

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6893938c0780832f9b2cea93c7417528