### PR TITLE
Open pendencias screen when checklist incomplete

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistActivity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistActivity.kt
@@ -46,37 +46,22 @@ class ChecklistActivity : AppCompatActivity() {
         val btn = findViewById<Button>(R.id.btnConcluir)
         btn.setOnClickListener {
             val pendentes = solicitacao.itens.filterIndexed { index, _ -> !checks[index].isChecked }
-            val checkedCount = checks.count { it.isChecked }
-            val completion = checkedCount.toDouble() / checks.size
 
             lifecycleScope.launch {
                 try {
-                    when {
-                        pendentes.isEmpty() -> {
-                            val intent = Intent(this@ChecklistActivity, ChecklistPosto01Activity::class.java)
-                            intent.putExtra("id", solicitacao.id)
-                            intent.putExtra("obra", solicitacao.obra)
-                            launcher.launch(intent)
-                        }
-                        completion >= 0.8 -> {
-                            val jsonPend = moshi.adapter<List<Item>>(
-                                Types.newParameterizedType(List::class.java, Item::class.java)
-                            ).toJson(pendentes)
-                            val intent = Intent(this@ChecklistActivity, ChecklistPosto01Activity::class.java)
-                            intent.putExtra("id", solicitacao.id)
-                            intent.putExtra("obra", solicitacao.obra)
-                            intent.putExtra("pendentes", jsonPend)
-                            launcher.launch(intent)
-                        }
-                        else -> {
-                            val jsonPend = moshi.adapter<List<Item>>(
-                                Types.newParameterizedType(List::class.java, Item::class.java)
-                            ).toJson(pendentes)
-                            val intent = Intent(this@ChecklistActivity, PendenciasActivity::class.java)
-                            intent.putExtra("id", solicitacao.id)
-                            intent.putExtra("pendencias", jsonPend)
-                            launcher.launch(intent)
-                        }
+                    if (pendentes.isEmpty()) {
+                        val intent = Intent(this@ChecklistActivity, ChecklistPosto01Activity::class.java)
+                        intent.putExtra("id", solicitacao.id)
+                        intent.putExtra("obra", solicitacao.obra)
+                        launcher.launch(intent)
+                    } else {
+                        val jsonPend = moshi.adapter<List<Item>>(
+                            Types.newParameterizedType(List::class.java, Item::class.java)
+                        ).toJson(pendentes)
+                        val intent = Intent(this@ChecklistActivity, PendenciasActivity::class.java)
+                        intent.putExtra("id", solicitacao.id)
+                        intent.putExtra("pendencias", jsonPend)
+                        launcher.launch(intent)
                     }
                 } catch (e: Exception) {
                     Toast.makeText(this@ChecklistActivity, "Erro ao enviar", Toast.LENGTH_SHORT).show()


### PR DESCRIPTION
## Summary
- redirect to pendencias when any checklist item is unchecked
- keep production variant in sync

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68939bb89c9c832fb49c90558e126c97