### PR TITLE
Finish checklist after pendencias

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistActivity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistActivity.kt
@@ -7,6 +7,7 @@ import android.widget.Button
 import android.widget.CheckBox
 import android.widget.LinearLayout
 import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
@@ -19,12 +20,15 @@ import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.launch
 
 class ChecklistActivity : AppCompatActivity() {
-    private val launcher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-        if (it.resultCode == Activity.RESULT_OK) {
-            setResult(Activity.RESULT_OK)
+    private lateinit var solicitacao: Solicitacao
+
+    private val launcher: ActivityResultLauncher<Intent> =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                setResult(Activity.RESULT_OK)
+            }
             finish()
         }
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -33,10 +37,10 @@ class ChecklistActivity : AppCompatActivity() {
         val json = intent.getStringExtra("solicitacao")
         val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
         val adapter = moshi.adapter(Solicitacao::class.java)
-        val solicitacao = adapter.fromJson(json ?: "") ?: return finish()
+        solicitacao = adapter.fromJson(json ?: "") ?: return finish()
 
         val container = findViewById<LinearLayout>(R.id.containerChecklist)
-        val checks = solicitacao.itens.map { item ->
+        val checks: List<CheckBox> = solicitacao.itens.map { item ->
             CheckBox(this).apply {
                 text = "${item.referencia} × ${item.quantidade}"
             }
@@ -45,36 +49,34 @@ class ChecklistActivity : AppCompatActivity() {
 
         val btn = findViewById<Button>(R.id.btnConcluir)
         btn.setOnClickListener {
-            val pendentes = solicitacao.itens.filterIndexed { index, _ -> !checks[index].isChecked }
+            val pendentes: List<Item> =
+                solicitacao.itens.filterIndexed { index, _ -> !checks[index].isChecked }
             val checkedCount = checks.count { it.isChecked }
             val completion = checkedCount.toDouble() / checks.size
 
             lifecycleScope.launch {
                 try {
                     when {
-                        pendentes.isEmpty() -> {
-                            val intent = Intent(this@ChecklistActivity, ChecklistPosto01Activity::class.java)
-                            intent.putExtra("id", solicitacao.id)
-                            intent.putExtra("obra", solicitacao.obra)
-                            launcher.launch(intent)
-                        }
-                        completion >= 0.8 -> {
-                            val jsonPend = moshi.adapter<List<Item>>(
-                                Types.newParameterizedType(List::class.java, Item::class.java)
-                            ).toJson(pendentes)
-                            val intent = Intent(this@ChecklistActivity, ChecklistPosto01Activity::class.java)
-                            intent.putExtra("id", solicitacao.id)
-                            intent.putExtra("obra", solicitacao.obra)
-                            intent.putExtra("pendentes", jsonPend)
+                        pendentes.isEmpty() || completion >= 0.8 -> {
+                            val intent = Intent(this@ChecklistActivity, ChecklistPosto01Activity::class.java).apply {
+                                putExtra("id", solicitacao.id)
+                                putExtra("obra", solicitacao.obra)
+                                if (pendentes.isNotEmpty()) {
+                                    val type = Types.newParameterizedType(List::class.java, Item::class.java)
+                                    val jsonPend = moshi.adapter<List<Item>>(type).toJson(pendentes)
+                                    putExtra("pendentes", jsonPend)
+                                }
+                            }
                             launcher.launch(intent)
                         }
                         else -> {
                             val jsonPend = moshi.adapter<List<Item>>(
                                 Types.newParameterizedType(List::class.java, Item::class.java)
                             ).toJson(pendentes)
-                            val intent = Intent(this@ChecklistActivity, PendenciasActivity::class.java)
-                            intent.putExtra("id", solicitacao.id)
-                            intent.putExtra("pendencias", jsonPend)
+                            val intent = Intent(this@ChecklistActivity, PendenciasActivity::class.java).apply {
+                                putExtra("id", solicitacao.id)
+                                putExtra("pendencias", jsonPend)
+                            }
                             launcher.launch(intent)
                         }
                     }


### PR DESCRIPTION
## Summary
- end checklist flow after pendências are sent
- route to pendências only when less than 80% of items are checked

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68939bb89c9c832fb49c90558e126c97