### PR TITLE
Add operator name field and include in checklist JSON

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/MainActivity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/MainActivity.kt
@@ -1,16 +1,19 @@
 package com.example.apestoque
 
+import android.content.Context
 import android.os.Bundle
+import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.core.widget.doAfterTextChanged
+import androidx.fragment.app.Fragment
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.viewpager2.widget.ViewPager2
-import com.example.apestoque.fragments.SolicitacoesFragment
-import com.example.apestoque.fragments.ComprasFragment
 import com.example.apestoque.fragments.AprovadoFragment
+import com.example.apestoque.fragments.ComprasFragment
+import com.example.apestoque.fragments.SolicitacoesFragment
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
-import androidx.fragment.app.Fragment
 
 class MainActivity : AppCompatActivity() {
 
@@ -20,6 +23,14 @@ class MainActivity : AppCompatActivity() {
 
         // Toolbar
         findViewById<Toolbar>(R.id.toolbar).also { setSupportActionBar(it) }
+
+        // Operador de Suprimentos
+        val prefs = getSharedPreferences("app", Context.MODE_PRIVATE)
+        val etOperador = findViewById<EditText>(R.id.etOperadorSuprimentos)
+        etOperador.setText(prefs.getString("operador_suprimentos", ""))
+        etOperador.doAfterTextChanged {
+            prefs.edit().putString("operador_suprimentos", it.toString()).apply()
+        }
 
         // Views
         val swipe = findViewById<SwipeRefreshLayout>(R.id.swipeRefresh)

--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Parte2Activity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Parte2Activity.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.Calendar
+import android.content.Context
 
 class ChecklistPosto01Parte2Activity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -32,6 +33,8 @@ class ChecklistPosto01Parte2Activity : AppCompatActivity() {
         val jsonPend = intent.getStringExtra("pendentes")
         val obra = intent.getStringExtra("obra") ?: ""
         val prevJson = intent.getStringExtra("itens") ?: "[]"
+        val prefs = getSharedPreferences("app", Context.MODE_PRIVATE)
+        val operador = prefs.getString("operador_suprimentos", "") ?: ""
 
         val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
         val pendentes = jsonPend?.let {
@@ -113,7 +116,7 @@ class ChecklistPosto01Parte2Activity : AppCompatActivity() {
             lifecycleScope.launch {
                 try {
                     val filePath = withContext(Dispatchers.IO) {
-                        val request = ChecklistRequest(obra, ano, itensChecklist)
+                        val request = ChecklistRequest(obra, ano, operador, itensChecklist)
                         val response = JsonNetworkModule.api.salvarChecklist(request)
                         if (pendentes == null) {
                             NetworkModule.api.aprovarSolicitacao(id)

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/ChecklistRequest.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/ChecklistRequest.kt
@@ -12,6 +12,7 @@ data class ChecklistItem(
 data class ChecklistRequest(
     val obra: String,
     val ano: String,
+    val operador: String,
     val itens: List<ChecklistItem>
 )
 

--- a/AppEstoque/app/src/main/res/layout/activity_main.xml
+++ b/AppEstoque/app/src/main/res/layout/activity_main.xml
@@ -13,10 +13,33 @@
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:background="@color/purple_500"
-            app:title="Checklist Solicitações"
-            app:titleTextColor="@android:color/white"/>
+            android:layout_height="wrap_content"
+            android:background="@color/purple_500">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="8dp">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Checklist Solicitações"
+                    android:textColor="@android:color/white"
+                    android:textSize="20sp"/>
+
+                <EditText
+                    android:id="@+id/etOperadorSuprimentos"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:background="@android:color/white"
+                    android:hint="Nome do operador Sumprimetos"
+                    android:maxLines="1"/>
+
+            </LinearLayout>
+        </androidx.appcompat.widget.Toolbar>
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tabLayout"


### PR DESCRIPTION
## Summary
- add operator name field in toolbar and save value with SharedPreferences
- include operator in ChecklistRequest and send during checklist submission

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6893bfcec22c832fa9da99c78af0193b