### PR TITLE
Group checklists by project and compare versions

### DIFF
--- a/site/projetista/templates/checklist_diff.html
+++ b/site/projetista/templates/checklist_diff.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block body %}
+<h1>Diferenças - {{ obra }}</h1>
+<p><strong>Comparando:</strong> {{ anterior }} → {{ filename }}</p>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Pergunta</th>
+      <th>Anterior</th>
+      <th>Atual</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for item in diff %}
+    <tr>
+      <td>{{ item.pergunta }}</td>
+      <td>{{ item.antigo }}</td>
+      <td>{{ item.novo }}</td>
+    </tr>
+    {% else %}
+    <tr><td colspan="3">Nenhuma diferença encontrada.</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/site/projetista/templates/checklist_list.html
+++ b/site/projetista/templates/checklist_list.html
@@ -2,14 +2,24 @@
 
 {% block body %}
 <h1>Checklists</h1>
-<ul class="list-group">
-  {% for arq in arquivos %}
-  <li class="list-group-item">
-    <a href="{{ url_for('projetista.checklist_view', filename=arq) }}">{{ arq }}</a>
-  </li>
-  {% else %}
-  <li class="list-group-item">Nenhum checklist disponível.</li>
+
+{% if projetos %}
+  {% for obra, arquivos in projetos.items() %}
+  <h2>{{ obra }}</h2>
+  <ul class="list-group mb-4">
+    {% for arq in arquivos %}
+    <li class="list-group-item">
+      <a href="{{ url_for('projetista.checklist_view', filename=arq.filename) }}">{{ arq.filename }}</a>
+      {% if arq.diff %}
+      <a class="ms-2" href="{{ url_for('projetista.checklist_diff', filename=arq.filename) }}">Diferenças</a>
+      {% endif %}
+    </li>
+    {% endfor %}
+  </ul>
   {% endfor %}
-</ul>
+{% else %}
+<p>Nenhum checklist disponível.</p>
+{% endif %}
+
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Group stored checklist JSONs by project and display each group's history
- Add page to show differences between sequential checklists of a project

## Testing
- `python -m py_compile site/projetista/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68949d93c06c832f9841b79260c57acf