### PR TITLE
feat: add checklist tab

### DIFF
--- a/APPproducao/app/src/main/java/com/example/appproducao/data/Checklist.kt
+++ b/APPproducao/app/src/main/java/com/example/appproducao/data/Checklist.kt
@@ -1,0 +1,16 @@
+package com.example.appproducao.data
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class ChecklistItem(
+    val descricao: String,
+    var status: String
+)
+
+@JsonClass(generateAdapter = true)
+data class Checklist(
+    val obra: String,
+    val itens: List<ChecklistItem>,
+    var responsavel: String? = null
+)


### PR DESCRIPTION
## Summary
- add Checklist tab for reviewing JSON checklists
- allow editing checklist items and saving result with responsible name

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6894d5f5f714832fb9ba7c02bdb8932d