### PR TITLE
Adicionar data de entrega às solicitações

### DIFF
--- a/APPproducao/AppEstoque/app/src/main/java/com/example/apestoque/adapter/SolicitacaoAdapter.kt
+++ b/APPproducao/AppEstoque/app/src/main/java/com/example/apestoque/adapter/SolicitacaoAdapter.kt
@@ -32,7 +32,9 @@ class SolicitacaoAdapter(
         val sol = lista[position]
         holder.tvId.text   = "#${sol.id}"
         holder.tvObra.text = sol.obra
-        holder.tvData.text = sol.data.replace("T","  ")  // formata legível
+        val criado = sol.data.replace("T","  ")
+        val entrega = sol.dataEntrega ?: ""
+        holder.tvData.text = "Criado: $criado\nEntrega: $entrega"  // mostra datas
         val itensTexto = sol.itens.joinToString("\n") {
             "• ${it.referencia} × ${it.quantidade}"
         }

--- a/APPproducao/AppEstoque/app/src/main/java/com/example/apestoque/data/Solicitacao.kt
+++ b/APPproducao/AppEstoque/app/src/main/java/com/example/apestoque/data/Solicitacao.kt
@@ -1,5 +1,6 @@
 package com.example.apestoque.data
 
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
@@ -15,5 +16,6 @@ data class Solicitacao(
     val data: String,
     val itens: List<Item>,
     val status: String? = null,
-    val pendencias: String? = null
+    val pendencias: String? = null,
+    @Json(name = "data_entrega") val dataEntrega: String? = null
 )

--- a/APPproducao/site/app.py
+++ b/APPproducao/site/app.py
@@ -65,6 +65,11 @@ def create_app():
                     "ALTER TABLE solicitacao ADD COLUMN pendencias TEXT"
                 )
                 db.session.commit()
+            if 'data_entrega' not in cols:
+                db.session.execute(
+                    "ALTER TABLE solicitacao ADD COLUMN data_entrega DATE"
+                )
+                db.session.commit()
 
         if 'item' in insp.get_table_names():
             cols = [c['name'] for c in insp.get_columns('item')]

--- a/APPproducao/site/models.py
+++ b/APPproducao/site/models.py
@@ -22,6 +22,7 @@ class Solicitacao(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     obra = db.Column(db.String(100), nullable=False)
     data = db.Column(db.DateTime, default=datetime.utcnow)
+    data_entrega = db.Column(db.Date, nullable=False)
     # novo status padrao indicando que a solicitacao esta em analise
     status = db.Column(db.String(20), default='analise')
     pendencias = db.Column(db.Text)

--- a/APPproducao/site/projetista/__init__.py
+++ b/APPproducao/site/projetista/__init__.py
@@ -9,6 +9,7 @@ import openpyxl
 import pytz
 from collections import Counter
 from flask import jsonify
+from datetime import datetime
 
 bp = Blueprint('projetista', __name__)
 
@@ -70,7 +71,9 @@ def iniciar_projeto():
 def nova_solicitacao():
     if request.method == 'POST':
         obra = request.form['obra'].strip()
-        sol = Solicitacao(obra=obra)
+        data_entrega_str = request.form['data_entrega']
+        data_entrega = datetime.strptime(data_entrega_str, '%Y-%m-%d').date()
+        sol = Solicitacao(obra=obra, data_entrega=data_entrega)
         db.session.add(sol)
         db.session.flush()
 
@@ -243,6 +246,7 @@ def api_listar_solicitacoes():
             "id": sol.id,
             "obra": sol.obra,
             "data": sol.data.isoformat(),
+            "data_entrega": sol.data_entrega.isoformat(),
             "itens": itens,
             "status": sol.status,
             "pendencias": sol.pendencias

--- a/APPproducao/site/projetista/templates/compras.html
+++ b/APPproducao/site/projetista/templates/compras.html
@@ -25,6 +25,7 @@
           <div class="card-header text-white">
             <strong>#{{ sol.id }}</strong> – {{ sol.obra }}
             <small class="d-block">{{ sol.data.strftime('%d/%m/%Y %H:%M') }}</small>
+            <small class="d-block">Entrega: {{ sol.data_entrega.strftime('%d/%m/%Y') }}</small>
           </div>
           <div class="card-body">
             <h6 class="fw-bold">Itens</h6>
@@ -194,6 +195,7 @@
           <div class="card-header text-white">
             <strong>#${sol.id}</strong> – ${sol.obra}
             <small class="d-block">${new Date(sol.data).toLocaleString()}</small>
+            <small class="d-block">Entrega: ${sol.data_entrega ? new Date(sol.data_entrega).toLocaleDateString() : ''}</small>
           </div>
           <div class="card-body">
             <h6 class="fw-bold">Itens</h6>

--- a/APPproducao/site/projetista/templates/index.html
+++ b/APPproducao/site/projetista/templates/index.html
@@ -15,6 +15,7 @@
       <tr>
         <th>ID</th>
         <th>Obra</th>
+        <th>Entrega</th>
         <th>Status</th>
         <th>Ações</th>
       </tr>
@@ -24,6 +25,7 @@
       <tr data-status="{{ sol.status }}">
         <td>{{ sol.id }}</td>
         <td>{{ sol.obra }}</td>
+        <td>{{ sol.data_entrega.strftime('%d/%m/%Y') }}</td>
         <td>
           {% if sol.status == 'analise' %}
             Em análise
@@ -41,7 +43,7 @@
       </tr>
     {% else %}
       <tr>
-        <td colspan="4" class="text-muted">Nenhuma solicitação registrada.</td>
+        <td colspan="5" class="text-muted">Nenhuma solicitação registrada.</td>
       </tr>
     {% endfor %}
     </tbody>
@@ -80,6 +82,7 @@
         tr.innerHTML = `
           <td>${sol.id}</td>
           <td>${sol.obra}</td>
+          <td>${sol.data_entrega ? new Date(sol.data_entrega).toLocaleDateString() : ''}</td>
           <td>${renderStatus(sol.status)}</td>
           <td>
             <form method="post" action="/projetista/solicitacao/${sol.id}/delete" onsubmit="return confirm('Confirma apagar?');">

--- a/APPproducao/site/projetista/templates/nova_solicitacao.html
+++ b/APPproducao/site/projetista/templates/nova_solicitacao.html
@@ -10,6 +10,10 @@
             <input type="text" class="form-control" id="obra" name="obra" placeholder="Obra" required>
             <label for="obra">Número da Obra</label>
           </div>
+          <div class="form-floating mb-3">
+            <input type="date" class="form-control" id="data_entrega" name="data_entrega" required>
+            <label for="data_entrega">Data de Entrega</label>
+          </div>
           <div class="mb-4">
             <label class="form-label fw-semibold">Importar de Excel</label>
             <input class="form-control" type="file" name="xlsx_file" accept=".xls,.xlsx">

--- a/APPproducao/site/projetista/templates/solicitacoes.html
+++ b/APPproducao/site/projetista/templates/solicitacoes.html
@@ -27,6 +27,7 @@
           <div>
             <strong>#{{ sol.id }}</strong> – {{ sol.obra }}
             <small class="d-block">{{ sol.local_time.strftime('%d/%m/%Y %H:%M') }}</small>
+            <small class="d-block">Entrega: {{ sol.data_entrega.strftime('%d/%m/%Y') }}</small>
           </div>
           <button class="btn btn-light btn-sm" type="button" data-bs-toggle="collapse" data-bs-target="#itens-{{ sol.id }}" aria-expanded="false" aria-controls="itens-{{ sol.id }}">
             Detalhes

--- a/AppEstoque/app/src/main/java/com/example/apestoque/adapter/SolicitacaoAdapter.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/adapter/SolicitacaoAdapter.kt
@@ -32,7 +32,9 @@ class SolicitacaoAdapter(
         val sol = lista[position]
         holder.tvId.text   = "#${sol.id}"
         holder.tvObra.text = sol.obra
-        holder.tvData.text = sol.data.replace("T","  ")  // formata legível
+        val criado = sol.data.replace("T","  ")
+        val entrega = sol.dataEntrega ?: ""
+        holder.tvData.text = "Criado: $criado\nEntrega: $entrega"  // mostra datas
         val itensTexto = sol.itens.joinToString("\n") {
             "• ${it.referencia} × ${it.quantidade}"
         }

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/Solicitacao.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/Solicitacao.kt
@@ -1,5 +1,6 @@
 package com.example.apestoque.data
 
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
@@ -15,5 +16,6 @@ data class Solicitacao(
     val data: String,
     val itens: List<Item>,
     val status: String? = null,
-    val pendencias: String? = null
+    val pendencias: String? = null,
+    @Json(name = "data_entrega") val dataEntrega: String? = null
 )

--- a/site/app.py
+++ b/site/app.py
@@ -67,6 +67,11 @@ def create_app():
                     "ALTER TABLE solicitacao ADD COLUMN pendencias TEXT"
                 )
                 db.session.commit()
+            if 'data_entrega' not in cols:
+                db.session.execute(
+                    "ALTER TABLE solicitacao ADD COLUMN data_entrega DATE"
+                )
+                db.session.commit()
 
         if 'item' in insp.get_table_names():
             cols = [c['name'] for c in insp.get_columns('item')]

--- a/site/models.py
+++ b/site/models.py
@@ -22,6 +22,7 @@ class Solicitacao(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     obra = db.Column(db.String(100), nullable=False)
     data = db.Column(db.DateTime, default=datetime.utcnow)
+    data_entrega = db.Column(db.Date, nullable=False)
     # novo status padrao indicando que a solicitacao esta em analise
     status = db.Column(db.String(20), default='analise')
     pendencias = db.Column(db.Text)

--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -120,8 +120,10 @@ def nova_solicitacao():
     if request.method == 'POST':
         obra = request.form['obra'].strip()
         ano = request.form.get('ano', '').strip()
+        data_entrega_str = request.form['data_entrega']
+        data_entrega = datetime.strptime(data_entrega_str, '%Y-%m-%d').date()
 
-        sol = Solicitacao(obra=obra)
+        sol = Solicitacao(obra=obra, data_entrega=data_entrega)
         db.session.add(sol)
         db.session.flush()
 
@@ -342,6 +344,7 @@ def api_listar_solicitacoes():
             "id": sol.id,
             "obra": sol.obra,
             "data": sol.data.isoformat(),
+            "data_entrega": sol.data_entrega.isoformat(),
             "itens": itens,
             "status": sol.status,
             "pendencias": sol.pendencias

--- a/site/projetista/templates/compras.html
+++ b/site/projetista/templates/compras.html
@@ -25,6 +25,7 @@
           <div class="card-header text-white">
             <strong>#{{ sol.id }}</strong> – {{ sol.obra }}
             <small class="d-block">{{ sol.data.strftime('%d/%m/%Y %H:%M') }}</small>
+            <small class="d-block">Entrega: {{ sol.data_entrega.strftime('%d/%m/%Y') }}</small>
           </div>
           <div class="card-body">
             <h6 class="fw-bold">Itens</h6>
@@ -194,6 +195,7 @@
           <div class="card-header text-white">
             <strong>#${sol.id}</strong> – ${sol.obra}
             <small class="d-block">${new Date(sol.data).toLocaleString()}</small>
+            <small class="d-block">Entrega: ${sol.data_entrega ? new Date(sol.data_entrega).toLocaleDateString() : ''}</small>
           </div>
           <div class="card-body">
             <h6 class="fw-bold">Itens</h6>

--- a/site/projetista/templates/index.html
+++ b/site/projetista/templates/index.html
@@ -15,6 +15,7 @@
       <tr>
         <th>ID</th>
         <th>Obra</th>
+        <th>Entrega</th>
         <th>Status</th>
         <th>Ações</th>
       </tr>
@@ -24,6 +25,7 @@
       <tr data-status="{{ sol.status }}">
         <td>{{ sol.id }}</td>
         <td>{{ sol.obra }}</td>
+        <td>{{ sol.data_entrega.strftime('%d/%m/%Y') }}</td>
         <td>
           {% if sol.status == 'analise' %}
             Em análise
@@ -47,7 +49,7 @@
       </tr>
     {% else %}
       <tr>
-        <td colspan="4" class="text-muted">Nenhuma solicitação registrada.</td>
+        <td colspan="5" class="text-muted">Nenhuma solicitação registrada.</td>
       </tr>
     {% endfor %}
     </tbody>
@@ -91,6 +93,7 @@
         tr.innerHTML = `
           <td>${sol.id}</td>
           <td>${sol.obra}</td>
+          <td>${sol.data_entrega ? new Date(sol.data_entrega).toLocaleDateString() : ''}</td>
           <td>${renderStatus(sol.status, sol.pendencias)}</td>
           <td>
             <form method="post" action="/projetista/solicitacao/${sol.id}/delete" onsubmit="return confirm('Confirma apagar?');">

--- a/site/projetista/templates/nova_solicitacao.html
+++ b/site/projetista/templates/nova_solicitacao.html
@@ -22,6 +22,11 @@
             <datalist id="obras_lista"></datalist>
           </div>
 
+          <div class="form-floating mb-3">
+            <input type="date" class="form-control" id="data_entrega" name="data_entrega" required>
+            <label for="data_entrega">Data de Entrega</label>
+          </div>
+
           <div class="mb-4">
             <label class="form-label fw-semibold">Importar de Excel</label>
             <input class="form-control" type="file" name="xlsx_file" accept=".xls,.xlsx">

--- a/site/projetista/templates/solicitacoes.html
+++ b/site/projetista/templates/solicitacoes.html
@@ -27,6 +27,7 @@
           <div>
             <strong>#{{ sol.id }}</strong> – {{ sol.obra }}
             <small class="d-block">{{ sol.local_time.strftime('%d/%m/%Y %H:%M') }}</small>
+            <small class="d-block">Entrega: {{ sol.data_entrega.strftime('%d/%m/%Y') }}</small>
           </div>
           <button class="btn btn-light btn-sm" type="button" data-bs-toggle="collapse" data-bs-target="#itens-{{ sol.id }}" aria-expanded="false" aria-controls="itens-{{ sol.id }}">
             Detalhes


### PR DESCRIPTION
## Resumo
- Adiciona campo **Data de Entrega** ao modelo de `Solicitacao` e ao formulário de criação
- Exibe a data de entrega nas listagens de solicitações, visão de compras e tabela de status
- Inclui a data de entrega no retorno da API e atualiza estruturas do app móvel

## Testes
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894dcfe2548832f855085bb23d9f731