### PR TITLE
Improve checklist revision display

### DIFF
--- a/site/projetista/templates/checklist_list.html
+++ b/site/projetista/templates/checklist_list.html
@@ -6,16 +6,29 @@
 {% if projetos %}
   {% for obra, arquivos in projetos.items() %}
   <h2>{{ obra }}</h2>
-  <ul class="list-group mb-4">
-    {% for arq in arquivos %}
-    <li class="list-group-item">
-      <a href="{{ url_for('projetista.checklist_view', filename=arq.filename) }}">{{ arq.filename }}</a>
-      {% if arq.diff %}
-      <a class="ms-2" href="{{ url_for('projetista.checklist_diff', filename=arq.filename) }}">Diferenças</a>
-      {% endif %}
-    </li>
-    {% endfor %}
-  </ul>
+  <table class="table table-striped mb-4">
+    <thead>
+      <tr>
+        <th>Revisão</th>
+        <th>Arquivo</th>
+        <th>Ações</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for arq in arquivos %}
+      <tr>
+        <td>{{ arq.revisao }}</td>
+        <td>{{ arq.filename }}</td>
+        <td>
+          <a href="{{ url_for('projetista.checklist_view', filename=arq.filename) }}">Ver</a>
+          {% if arq.diff %}
+          | <a href="{{ url_for('projetista.checklist_diff', filename=arq.filename) }}">Diferenças</a>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
   {% endfor %}
 {% else %}
 <p>Nenhum checklist disponível.</p>

--- a/site/projetista/templates/checklist_view.html
+++ b/site/projetista/templates/checklist_view.html
@@ -7,9 +7,14 @@
 <p><strong>Ano:</strong> {{ dados.ano }}</p>
 <p><strong>Suprimento:</strong> {{ dados.suprimento }}</p>
 
+{% if prev_filename %}
+<p><a href="{{ url_for('projetista.checklist_diff', filename=filename) }}">Comparar com revisão anterior</a></p>
+{% endif %}
+
 <table class="table table-striped">
   <thead>
     <tr>
+      <th>#</th>
       <th>Pergunta</th>
       <th>Resposta</th>
     </tr>
@@ -17,6 +22,7 @@
   <tbody>
     {% for item in dados.itens %}
     <tr>
+      <td>{{ loop.index }}</td>
       <td>{{ item.pergunta }}</td>
       <td>{{ item.resposta | join(', ') }}</td>
     </tr>


### PR DESCRIPTION
## Summary
- number checklist revisions and show compare links
- display checklist items with numeric index
- add revision comparison option from checklist view

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894ffac6f3c832fb84d427939a971ee