### PR TITLE
Add checklist viewer

### DIFF
--- a/APPproducao/site/json_api/__init__.py
+++ b/APPproducao/site/json_api/__init__.py
@@ -1,0 +1,2 @@
+# Placeholder package for stored checklist JSON files
+

--- a/APPproducao/site/projetista/__init__.py
+++ b/APPproducao/site/projetista/__init__.py
@@ -10,8 +10,14 @@ import pytz
 from collections import Counter
 from flask import jsonify
 from datetime import datetime
+import os
 
 bp = Blueprint('projetista', __name__)
+
+# Diretório onde os arquivos de checklist (JSON) são salvos
+CHECKLIST_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', 'json_api')
+)
 
 @bp.route('/')
 @login_required
@@ -224,6 +230,102 @@ def export_template():
         as_attachment=True,
         download_name="template_solicitacao.xlsx",
         mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+
+
+@bp.route('/checklist')
+@login_required
+def checklist_list():
+    """Lista os checklists agrupados por obra."""
+    projetos = {}
+    if os.path.isdir(CHECKLIST_DIR):
+        for nome in os.listdir(CHECKLIST_DIR):
+            if not nome.endswith('.json'):
+                continue
+            caminho = os.path.join(CHECKLIST_DIR, nome)
+            try:
+                with open(caminho, encoding='utf-8') as f:
+                    dados = json.load(f)
+                obra = dados.get('obra', 'Desconhecida') or 'Desconhecida'
+            except Exception:
+                obra = 'Desconhecida'
+            projetos.setdefault(obra, []).append({'filename': nome})
+
+    for obra, arquivos in projetos.items():
+        arquivos.sort(key=lambda a: a['filename'])
+        for i in range(1, len(arquivos)):
+            arquivos[i]['diff'] = arquivos[i-1]['filename']
+
+    return render_template('checklist_list.html', projetos=projetos)
+
+
+@bp.route('/checklist/<path:filename>')
+@login_required
+def checklist_view(filename):
+    caminho = os.path.join(CHECKLIST_DIR, filename)
+    if not os.path.isfile(caminho):
+        flash('Arquivo não encontrado.', 'danger')
+        return redirect(url_for('projetista.checklist_list'))
+    with open(caminho, encoding='utf-8') as f:
+        dados = json.load(f)
+    return render_template('checklist_view.html', filename=filename, dados=dados)
+
+
+@bp.route('/checklist/diff/<path:filename>')
+@login_required
+def checklist_diff(filename):
+    """Exibe as diferenças entre o checklist selecionado e o anterior."""
+    caminho = os.path.join(CHECKLIST_DIR, filename)
+    if not os.path.isfile(caminho):
+        flash('Arquivo não encontrado.', 'danger')
+        return redirect(url_for('projetista.checklist_list'))
+
+    with open(caminho, encoding='utf-8') as f:
+        atual = json.load(f)
+
+    obra = atual.get('obra', 'Desconhecida') or 'Desconhecida'
+    safe_obra = "".join(c for c in obra if c.isalnum() or c in ('-','_')) or 'obra'
+
+    todos = [n for n in os.listdir(CHECKLIST_DIR)
+             if n.endswith('.json') and n.startswith(f"checklist_{safe_obra}_")]
+    todos.sort()
+    try:
+        idx = todos.index(filename)
+    except ValueError:
+        idx = -1
+
+    if idx <= 0:
+        flash('Não há checklist anterior para comparação.', 'warning')
+        return redirect(url_for('projetista.checklist_view', filename=filename))
+
+    anterior_nome = todos[idx - 1]
+    caminho_ant = os.path.join(CHECKLIST_DIR, anterior_nome)
+    with open(caminho_ant, encoding='utf-8') as f:
+        anterior = json.load(f)
+
+    antigos = {i['pergunta']: i.get('resposta', [])
+               for i in anterior.get('itens', [])}
+    novos = {i['pergunta']: i.get('resposta', [])
+             for i in atual.get('itens', [])}
+
+    diff = []
+    perguntas = sorted(set(antigos) | set(novos))
+    for pergunta in perguntas:
+        resp_ant = antigos.get(pergunta, [])
+        resp_novo = novos.get(pergunta, [])
+        if resp_ant != resp_novo:
+            diff.append({
+                'pergunta': pergunta,
+                'antigo': ', '.join(map(str, resp_ant)),
+                'novo': ', '.join(map(str, resp_novo))
+            })
+
+    return render_template(
+        'checklist_diff.html',
+        filename=filename,
+        anterior=anterior_nome,
+        diff=diff,
+        obra=obra,
     )
 
 

--- a/APPproducao/site/projetista/templates/base.html
+++ b/APPproducao/site/projetista/templates/base.html
@@ -37,6 +37,7 @@
             <li class="nav-item"><a class="nav-link" href="{{ url_for('projetista.solicitacoes') }}">Historico de Solicitações</a></li>
             <li class="nav-item"><a class="nav-link" href="{{ url_for('projetista.iniciar_projeto') }}">Iniciar Projeto</a></li>
             <li class="nav-item"><a class="nav-link" href="{{ url_for('projetista.comparador') }}">Comparador</a></li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('projetista.checklist_list') }}">Checklist</a></li>
             {% if current_user.is_authenticated and current_user.role == 'admin' %}
               <li class="nav-item"><a class="nav-link" href="{{ url_for('projetista.config') }}">Configurações</a></li>
             {% endif %}

--- a/APPproducao/site/projetista/templates/checklist_diff.html
+++ b/APPproducao/site/projetista/templates/checklist_diff.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block body %}
+<h1>Diferenças - {{ obra }}</h1>
+<p><strong>Comparando:</strong> {{ anterior }} → {{ filename }}</p>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Pergunta</th>
+      <th>Anterior</th>
+      <th>Atual</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for item in diff %}
+    <tr>
+      <td>{{ item.pergunta }}</td>
+      <td>{{ item.antigo }}</td>
+      <td>{{ item.novo }}</td>
+    </tr>
+    {% else %}
+    <tr><td colspan="3">Nenhuma diferença encontrada.</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/APPproducao/site/projetista/templates/checklist_list.html
+++ b/APPproducao/site/projetista/templates/checklist_list.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block body %}
+<h1>Checklists</h1>
+
+{% if projetos %}
+  {% for obra, arquivos in projetos.items() %}
+  <h2>{{ obra }}</h2>
+  <ul class="list-group mb-4">
+    {% for arq in arquivos %}
+    <li class="list-group-item">
+      <a href="{{ url_for('projetista.checklist_view', filename=arq.filename) }}">{{ arq.filename }}</a>
+      {% if arq.diff %}
+      <a class="ms-2" href="{{ url_for('projetista.checklist_diff', filename=arq.filename) }}">Diferenças</a>
+      {% endif %}
+    </li>
+    {% endfor %}
+  </ul>
+  {% endfor %}
+{% else %}
+<p>Nenhum checklist disponível.</p>
+{% endif %}
+
+{% endblock %}
+

--- a/APPproducao/site/projetista/templates/checklist_view.html
+++ b/APPproducao/site/projetista/templates/checklist_view.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block body %}
+<h1>{{ filename }}</h1>
+
+<p><strong>Obra:</strong> {{ dados.obra }}</p>
+<p><strong>Ano:</strong> {{ dados.ano }}</p>
+<p><strong>Suprimento:</strong> {{ dados.suprimento }}</p>
+
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Pergunta</th>
+      <th>Resposta</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for item in dados.itens %}
+    <tr>
+      <td>{{ item.pergunta }}</td>
+      <td>{{ item.resposta | join(', ') }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- correct checklist directory path in AppProducao so JSON files from `site/json_api` are displayed
- add placeholder `json_api` package for storing checklist data

## Testing
- `python -m py_compile APPproducao/site/projetista/__init__.py`
- `python -m py_compile APPproducao/site/json_api/__init__.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895004a7a98832f9fb957fc0bce035a