### PR TITLE
Add checklist tab displaying server JSON in AppOficina

### DIFF
--- a/AppOficina/app/build.gradle.kts
+++ b/AppOficina/app/build.gradle.kts
@@ -33,6 +33,7 @@ android {
     kotlinOptions {
         jvmTarget = "11"
     }
+    sourceSets["main"].assets.srcDirs("src/main/assets", "../../site/json_api")
 }
 
 dependencies {
@@ -40,6 +41,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
+    implementation(libs.androidx.viewpager2)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/AppOficina/app/src/main/AndroidManifest.xml
+++ b/AppOficina/app/src/main/AndroidManifest.xml
@@ -10,6 +10,15 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.AppOficina" />
+        android:theme="@style/Theme.AppOficina">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
 
 </manifest>

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistFragment.kt
@@ -1,0 +1,45 @@
+package com.example.appoficina
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.CheckBox
+import android.widget.LinearLayout
+import androidx.fragment.app.Fragment
+import org.json.JSONObject
+
+class ChecklistFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_checklist, container, false)
+        val checklistContainer: LinearLayout = view.findViewById(R.id.checklist_container)
+        val items = loadItemsFromAssets()
+        for (item in items) {
+            val checkBox = CheckBox(requireContext())
+            checkBox.text = item
+            checklistContainer.addView(checkBox)
+        }
+        return view
+    }
+
+    private fun loadItemsFromAssets(): List<String> {
+        val result = mutableListOf<String>()
+        val assetManager = requireContext().assets
+        val files = assetManager.list("")?.filter { it.endsWith(".json") } ?: emptyList()
+        for (file in files) {
+            val jsonStr = assetManager.open(file).bufferedReader().use { it.readText() }
+            val obj = JSONObject(jsonStr)
+            val array = obj.optJSONArray("items")
+            if (array != null) {
+                for (i in 0 until array.length()) {
+                    result.add(array.optString(i))
+                }
+            }
+        }
+        return result
+    }
+}

--- a/AppOficina/app/src/main/java/com/example/appoficina/HomeFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/HomeFragment.kt
@@ -1,0 +1,17 @@
+package com.example.appoficina
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+
+class HomeFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_home, container, false)
+    }
+}

--- a/AppOficina/app/src/main/java/com/example/appoficina/MainActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/MainActivity.kt
@@ -1,0 +1,31 @@
+package com.example.appoficina
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import androidx.viewpager2.widget.ViewPager2
+import com.google.android.material.tabs.TabLayout
+import com.google.android.material.tabs.TabLayoutMediator
+
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        val viewPager: ViewPager2 = findViewById(R.id.view_pager)
+        val tabLayout: TabLayout = findViewById(R.id.tab_layout)
+
+        val fragments: List<Fragment> = listOf(HomeFragment(), ChecklistFragment())
+        val titles = listOf("Home", "Checklist")
+
+        viewPager.adapter = object : FragmentStateAdapter(this) {
+            override fun getItemCount(): Int = fragments.size
+            override fun createFragment(position: Int): Fragment = fragments[position]
+        }
+
+        TabLayoutMediator(tabLayout, viewPager) { tab, position ->
+            tab.text = titles[position]
+        }.attach()
+    }
+}

--- a/AppOficina/app/src/main/res/layout/activity_main.xml
+++ b/AppOficina/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/tab_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/view_pager"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+</LinearLayout>

--- a/AppOficina/app/src/main/res/layout/fragment_checklist.xml
+++ b/AppOficina/app/src/main/res/layout/fragment_checklist.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:id="@+id/checklist_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp" />
+</ScrollView>

--- a/AppOficina/app/src/main/res/layout/fragment_home.xml
+++ b/AppOficina/app/src/main/res/layout/fragment_home.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="Home" />
+</FrameLayout>

--- a/AppOficina/gradle/libs.versions.toml
+++ b/AppOficina/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 appcompat = "1.7.1"
 material = "1.12.0"
+viewpager2 = "1.0.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -15,6 +16,7 @@ androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "j
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+androidx-viewpager2 = { group = "androidx.viewpager2", name = "viewpager2", version.ref = "viewpager2" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/site/json_api/exemplo.json
+++ b/site/json_api/exemplo.json
@@ -1,0 +1,7 @@
+{
+  "items": [
+    "Trocar óleo",
+    "Verificar freios",
+    "Checar pneus"
+  ]
+}


### PR DESCRIPTION
## Summary
- show JSON checklists stored under `site/json_api` inside new "Checklist" tab
- wire up TabLayout and ViewPager2 with placeholder Home screen
- configure Gradle to bundle checklist JSON files as app assets
- set `android:exported="true"` on `MainActivity` to satisfy Android 12 manifest requirements

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6895f61e5a14832f8734cd651c029ebb