### PR TITLE
Fetch checklist projects from server

### DIFF
--- a/AppOficina/app/src/main/AndroidManifest.xml
+++ b/AppOficina/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistFragment.kt
@@ -4,10 +4,15 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.graphics.Typeface
 import android.widget.CheckBox
 import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.fragment.app.Fragment
 import org.json.JSONObject
+import java.net.URL
+import android.os.Handler
+import android.os.Looper
 
 class ChecklistFragment : Fragment() {
     override fun onCreateView(
@@ -17,27 +22,43 @@ class ChecklistFragment : Fragment() {
     ): View? {
         val view = inflater.inflate(R.layout.fragment_checklist, container, false)
         val checklistContainer: LinearLayout = view.findViewById(R.id.checklist_container)
-        val items = loadItemsFromAssets()
-        for (item in items) {
-            val checkBox = CheckBox(requireContext())
-            checkBox.text = item
-            checklistContainer.addView(checkBox)
-        }
+        Thread {
+            val projects = loadProjectsFromServer()
+            Handler(Looper.getMainLooper()).post {
+                for ((name, items) in projects) {
+                    val title = TextView(requireContext())
+                    title.text = name
+                    title.setTypeface(null, Typeface.BOLD)
+                    checklistContainer.addView(title)
+                    for (item in items) {
+                        val checkBox = CheckBox(requireContext())
+                        checkBox.text = item
+                        checklistContainer.addView(checkBox)
+                    }
+                }
+            }
+        }.start()
         return view
     }
 
-    private fun loadItemsFromAssets(): List<String> {
-        val result = mutableListOf<String>()
-        val assetManager = requireContext().assets
-        val files = assetManager.list("")?.filter { it.endsWith(".json") } ?: emptyList()
-        for (file in files) {
-            val jsonStr = assetManager.open(file).bufferedReader().use { it.readText() }
-            val obj = JSONObject(jsonStr)
-            val array = obj.optJSONArray("items")
-            if (array != null) {
-                for (i in 0 until array.length()) {
-                    result.add(array.optString(i))
+    private fun loadProjectsFromServer(): Map<String, List<String>> {
+        val url = "http://192.168.0.135:5000/json_api/projects"
+        val jsonStr = URL(url).readText()
+        val obj = JSONObject(jsonStr)
+        val projectsObj = obj.optJSONObject("projects")
+        val result = mutableMapOf<String, List<String>>()
+        if (projectsObj != null) {
+            val keys = projectsObj.keys()
+            while (keys.hasNext()) {
+                val name = keys.next()
+                val array = projectsObj.optJSONArray(name)
+                val items = mutableListOf<String>()
+                if (array != null) {
+                    for (i in 0 until array.length()) {
+                        items.add(array.optString(i))
+                    }
                 }
+                result[name] = items
             }
         }
         return result

--- a/site/json_api/__init__.py
+++ b/site/json_api/__init__.py
@@ -7,8 +7,10 @@ bp = Blueprint('json_api', __name__)
 
 BASE_DIR = os.path.dirname(__file__)
 
+
 @bp.route('/checklist', methods=['POST'])
 def salvar_checklist():
+    """Save a checklist payload to a timestamped JSON file."""
     data = request.get_json() or {}
     obra = data.get('obra', 'desconhecida')
 
@@ -22,3 +24,21 @@ def salvar_checklist():
         json.dump(data, f, ensure_ascii=False, indent=2)
 
     return jsonify({'caminho': file_path})
+
+
+@bp.route('/projects', methods=['GET'])
+def listar_projetos():
+    """Return names and items of all checklist JSON files."""
+    files = [f for f in os.listdir(BASE_DIR) if f.endswith('.json')]
+    projetos = {}
+    for nome in files:
+        caminho = os.path.join(BASE_DIR, nome)
+        try:
+            with open(caminho, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+                itens = data.get('items', [])
+            projetos[nome] = itens
+        except Exception:
+            continue
+    return jsonify({'projects': projetos})
+


### PR DESCRIPTION
## Summary
- Add Flask route `/json_api/projects` to expose checklist JSON files and their items
- Update Android Checklist tab to consume the new API endpoint

## Testing
- `python -m py_compile site/json_api/__init__.py`
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68960489de54832fb339395dcd49f330