### PR TITLE
Add checklist editing from JSON files

### DIFF
--- a/AppOficina/app/src/main/AndroidManifest.xml
+++ b/AppOficina/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".ChecklistDetailActivity" android:exported="false"/>
     </application>
 
 </manifest>

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistDetailActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistDetailActivity.kt
@@ -1,0 +1,75 @@
+package com.example.appoficina
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.CheckBox
+import android.widget.LinearLayout
+import androidx.appcompat.app.AppCompatActivity
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
+
+class ChecklistDetailActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_checklist_detail)
+
+        val container: LinearLayout = findViewById(R.id.checklist_detail_container)
+        val fileName = intent.getStringExtra("file_name")
+        val jsonStr = if (fileName != null) {
+            assets.open(fileName).bufferedReader().use { it.readText() }
+        } else {
+            "{}"
+        }
+        val obj = JSONObject(jsonStr)
+        val itensArray = obj.optJSONArray("itens")
+        val checkBoxes = mutableListOf<CheckBox>()
+        if (itensArray != null) {
+            for (i in 0 until itensArray.length()) {
+                val itemObj = itensArray.getJSONObject(i)
+                val pergunta = itemObj.optString("pergunta")
+                val respostaArray = itemObj.optJSONArray("resposta")
+                val checkBox = CheckBox(this)
+                checkBox.text = pergunta
+                if (respostaArray != null && respostaArray.toString().contains("C")) {
+                    checkBox.isChecked = true
+                }
+                container.addView(checkBox)
+                checkBoxes.add(checkBox)
+            }
+        }
+
+        val saveButton: Button = findViewById(R.id.save_button)
+        saveButton.setOnClickListener {
+            if (itensArray != null) {
+                for (i in 0 until itensArray.length()) {
+                    val itemObj = itensArray.getJSONObject(i)
+                    val cb = checkBoxes[i]
+                    val newRes = if (cb.isChecked) JSONArray(listOf("C")) else JSONArray()
+                    itemObj.put("resposta", newRes)
+                }
+            }
+            Thread {
+                sendChecklistToServer(obj)
+            }.start()
+            finish()
+        }
+    }
+
+    private fun sendChecklistToServer(json: JSONObject) {
+        val url = URL("http://192.168.0.135:5000/json_api/upload")
+        val conn = url.openConnection() as HttpURLConnection
+        conn.requestMethod = "POST"
+        conn.doOutput = true
+        conn.setRequestProperty("Content-Type", "application/json")
+        val writer = OutputStreamWriter(conn.outputStream)
+        writer.write(json.toString())
+        writer.flush()
+        writer.close()
+        conn.responseCode
+        conn.disconnect()
+    }
+}
+

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistFragment.kt
@@ -1,64 +1,38 @@
 package com.example.appoficina
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.CheckBox
 import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.fragment.app.Fragment
-import org.json.JSONObject
-import java.net.URL
-import android.os.Handler
-import android.os.Looper
 
 class ChecklistFragment : Fragment() {
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View? {
         val view = inflater.inflate(R.layout.fragment_checklist, container, false)
         val checklistContainer: LinearLayout = view.findViewById(R.id.checklist_container)
-        Thread {
-            val projects = loadProjectsFromServer()
-            Handler(Looper.getMainLooper()).post {
-                for ((name, items) in projects) {
-                    val title = android.widget.TextView(requireContext())
-                    title.text = name
-                    title.setTypeface(null, android.graphics.Typeface.BOLD)
-                    checklistContainer.addView(title)
-                    for (item in items) {
-                        val checkBox = CheckBox(requireContext())
-                        checkBox.text = item
-                        checklistContainer.addView(checkBox)
-                    }
-                }
+
+        val assetManager = requireContext().assets
+        val files = assetManager.list("")?.filter { it.endsWith(".json") } ?: emptyList()
+        for (fileName in files) {
+            val textView = TextView(requireContext())
+            textView.text = fileName
+            textView.setPadding(0, 0, 0, 16)
+            textView.setOnClickListener {
+                val intent = Intent(requireContext(), ChecklistDetailActivity::class.java)
+                intent.putExtra("file_name", fileName)
+                startActivity(intent)
             }
-        }.start()
+            checklistContainer.addView(textView)
+        }
+
         return view
     }
-
-    private fun loadProjectsFromServer(): Map<String, List<String>> {
-        val url = "http://192.168.0.135:5000/json_api/projects"
-        val jsonStr = URL(url).readText()
-        val obj = JSONObject(jsonStr)
-        val projectsObj = obj.optJSONObject("projects")
-        val result = mutableMapOf<String, List<String>>()
-        if (projectsObj != null) {
-            val keys = projectsObj.keys()
-            while (keys.hasNext()) {
-                val name = keys.next()
-                val array = projectsObj.optJSONArray(name)
-                val items = mutableListOf<String>()
-                if (array != null) {
-                    for (i in 0 until array.length()) {
-                        items.add(array.optString(i))
-                    }
-                }
-                result[name] = items
-            }
-        }
-        return result
-    }
 }
+

--- a/AppOficina/app/src/main/res/layout/activity_checklist_detail.xml
+++ b/AppOficina/app/src/main/res/layout/activity_checklist_detail.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <LinearLayout
+            android:id="@+id/checklist_detail_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp" />
+    </ScrollView>
+
+    <Button
+        android:id="@+id/save_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Salvar" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- List JSON checklists in the app and allow opening them for editing
- Provide activity with checkboxes that updates answers and posts JSON back to the server

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_6896260d7cec832f9c2aab49ac7ca665