### PR TITLE
Fix project list loading in AppOficina

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/Posto01MateriaisFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/Posto01MateriaisFragment.kt
@@ -23,31 +23,40 @@ class Posto01MateriaisFragment : Fragment() {
         val listContainer: LinearLayout = view.findViewById(R.id.projetos_container)
 
         Thread {
-            try {
-                val url = URL("http://10.0.2.2:5000/json_api/projects")
-                val conn = url.openConnection() as HttpURLConnection
-                val response = conn.inputStream.bufferedReader().use { it.readText() }
-                conn.disconnect()
+            val urls = listOf(
+                "http://10.0.2.2:5000/json_api/projects",
+                "http://192.168.0.151:5000/json_api/projects"
+            )
+            for (address in urls) {
+                try {
+                    val url = URL(address)
+                    val conn = url.openConnection() as HttpURLConnection
+                    val response = conn.inputStream.bufferedReader().use { it.readText() }
+                    conn.disconnect()
 
-                val projetos = JSONObject(response).optJSONArray("projetos") ?: JSONArray()
-                requireActivity().runOnUiThread {
-                    for (i in 0 until projetos.length()) {
-                        val obj = projetos.getJSONObject(i)
-                        val obra = obj.optString("obra")
-                        val ano = obj.optString("ano")
-                        val tv = TextView(requireContext())
-                        tv.text = String.format("%02d - %s - %s", i + 1, obra, ano)
-                        tv.setPadding(0, 0, 0, 16)
-                        tv.setOnClickListener {
-                            val intent = Intent(requireContext(), ChecklistPosto01Parte2Activity::class.java)
-                            intent.putExtra("obra", obra)
-                            intent.putExtra("ano", ano)
-                            startActivity(intent)
+                    val projetos = JSONObject(response).optJSONArray("projetos") ?: JSONArray()
+                    requireActivity().runOnUiThread {
+                        listContainer.removeAllViews()
+                        for (i in 0 until projetos.length()) {
+                            val obj = projetos.getJSONObject(i)
+                            val obra = obj.optString("obra")
+                            val ano = obj.optString("ano")
+                            val tv = TextView(requireContext())
+                            tv.text = String.format("%02d - %s - %s", i + 1, obra, ano)
+                            tv.setPadding(0, 0, 0, 16)
+                            tv.setOnClickListener { _: View ->
+                                val intent: Intent = Intent(requireContext(), ChecklistPosto01Parte2Activity::class.java)
+                                intent.putExtra("obra", obra)
+                                intent.putExtra("ano", ano)
+                                startActivity(intent)
+                            }
+                            listContainer.addView(tv)
                         }
-                        listContainer.addView(tv)
                     }
+                    break
+                } catch (_: Exception) {
+                    // tenta proximo endereco
                 }
-            } catch (_: Exception) {
             }
         }.start()
 


### PR DESCRIPTION
## Summary
- Try alternate project API address in AppOficina materials tab
- Clarify intent creation and click listener type to avoid unresolved reference errors

## Testing
- `sh gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6897a92b3e74832fb12987debc6ce24e