### PR TITLE
feat(appoficina): add admin settings with tab passwords

### DIFF
--- a/AppOficina/app/src/main/AndroidManifest.xml
+++ b/AppOficina/app/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
             </intent-filter>
         </activity>
         <activity android:name=".ChecklistPosto01Parte2Activity" android:exported="false" />
+        <activity android:name=".AdminConfigActivity" android:exported="false" />
     </application>
 
 </manifest>

--- a/AppOficina/app/src/main/java/com/example/appoficina/AdminConfigActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/AdminConfigActivity.kt
@@ -1,0 +1,63 @@
+package com.example.appoficina
+
+import android.content.SharedPreferences
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import androidx.appcompat.app.AppCompatActivity
+
+class AdminConfigActivity : AppCompatActivity() {
+    private lateinit var prefs: SharedPreferences
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_admin_config)
+
+        prefs = getSharedPreferences("config", MODE_PRIVATE)
+
+        val adminUser = findViewById<EditText>(R.id.edit_admin_user)
+        val adminPass = findViewById<EditText>(R.id.edit_admin_pass)
+        val pass02 = findViewById<EditText>(R.id.edit_pass_tab02)
+        val pass03 = findViewById<EditText>(R.id.edit_pass_tab03)
+        val pass04 = findViewById<EditText>(R.id.edit_pass_tab04)
+        val pass05 = findViewById<EditText>(R.id.edit_pass_tab05)
+        val pass06 = findViewById<EditText>(R.id.edit_pass_tab06)
+        val pass061 = findViewById<EditText>(R.id.edit_pass_tab06_1)
+        val pass07 = findViewById<EditText>(R.id.edit_pass_tab07)
+        val pass08 = findViewById<EditText>(R.id.edit_pass_tab08)
+        val pass08Teste = findViewById<EditText>(R.id.edit_pass_tab08_teste)
+        val pass09 = findViewById<EditText>(R.id.edit_pass_tab09)
+
+        adminUser.setText(prefs.getString("admin_user", "admin"))
+        adminPass.setText(prefs.getString("admin_pass", "admin"))
+        pass02.setText(prefs.getString("pass_02", ""))
+        pass03.setText(prefs.getString("pass_03", ""))
+        pass04.setText(prefs.getString("pass_04", ""))
+        pass05.setText(prefs.getString("pass_05", ""))
+        pass06.setText(prefs.getString("pass_06", ""))
+        pass061.setText(prefs.getString("pass_06_1", ""))
+        pass07.setText(prefs.getString("pass_07", ""))
+        pass08.setText(prefs.getString("pass_08", ""))
+        pass08Teste.setText(prefs.getString("pass_08_teste", ""))
+        pass09.setText(prefs.getString("pass_09", ""))
+
+        findViewById<Button>(R.id.button_save).setOnClickListener {
+            prefs.edit().apply {
+                putString("admin_user", adminUser.text.toString())
+                putString("admin_pass", adminPass.text.toString())
+                putString("pass_02", pass02.text.toString())
+                putString("pass_03", pass03.text.toString())
+                putString("pass_04", pass04.text.toString())
+                putString("pass_05", pass05.text.toString())
+                putString("pass_06", pass06.text.toString())
+                putString("pass_06_1", pass061.text.toString())
+                putString("pass_07", pass07.text.toString())
+                putString("pass_08", pass08.text.toString())
+                putString("pass_08_teste", pass08Teste.text.toString())
+                putString("pass_09", pass09.text.toString())
+                apply()
+            }
+            finish()
+        }
+    }
+}

--- a/AppOficina/app/src/main/java/com/example/appoficina/MainActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/MainActivity.kt
@@ -1,6 +1,14 @@
 package com.example.appoficina
 
+import android.content.Intent
+import android.content.SharedPreferences
 import android.os.Bundle
+import android.text.InputType
+import android.widget.Button
+import android.widget.EditText
+import android.widget.LinearLayout
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
@@ -9,18 +17,84 @@ import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 
 class MainActivity : AppCompatActivity() {
+    private lateinit var prefs: SharedPreferences
+    private var previousTab = 0
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
+        prefs = getSharedPreferences("config", MODE_PRIVATE)
+
+        val adminButton: Button = findViewById(R.id.admin_button)
         val viewPager: ViewPager2 = findViewById(R.id.view_pager)
         val tabLayout: TabLayout = findViewById(R.id.tab_layout)
 
+        adminButton.setOnClickListener {
+            val userInput = EditText(this)
+            val passInput = EditText(this).apply {
+                inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
+            }
+            val layout = LinearLayout(this).apply {
+                orientation = LinearLayout.VERTICAL
+                addView(userInput)
+                addView(passInput)
+            }
+            AlertDialog.Builder(this)
+                .setTitle("Login Admin")
+                .setView(layout)
+                .setPositiveButton("OK") { _, _ ->
+                    val savedUser = prefs.getString("admin_user", "admin")
+                    val savedPass = prefs.getString("admin_pass", "admin")
+                    if (userInput.text.toString() == savedUser && passInput.text.toString() == savedPass) {
+                        startActivity(Intent(this, AdminConfigActivity::class.java))
+                    } else {
+                        Toast.makeText(this, "Credenciais inválidas", Toast.LENGTH_SHORT).show()
+                    }
+                }
+                .setNegativeButton("Cancelar", null)
+                .show()
+        }
+
         val fragments: List<Fragment> = listOf(
             Posto01MateriaisFragment(),
-            Posto02OficinaFragment()
+            Posto02OficinaFragment(),
+            SimpleTextFragment.newInstance("03 - POSTO - 03 PRÉ-MONTAGEM - 01"),
+            SimpleTextFragment.newInstance("04 - POSTO - 04 BARRAMENTO"),
+            SimpleTextFragment.newInstance("05 - POSTO - 05 CABLAGEM - 01"),
+            SimpleTextFragment.newInstance("06 - POSTO - 06 PRÉ-MONTAGEM - 02"),
+            SimpleTextFragment.newInstance("06.1 - POSTO - 06 CABLAGEM - 02"),
+            SimpleTextFragment.newInstance("07 - POSTO - 08 IQM"),
+            SimpleTextFragment.newInstance("08 - POSTO - 08 IQE"),
+            SimpleTextFragment.newInstance("POSTO - 08 TESTE"),
+            SimpleTextFragment.newInstance("POSTO - 09 EXPEDIÇÃO")
         )
-        val titles = listOf("01 - Posto 01 - Materiais", "02 - POSTO - 02 OFICINA")
+        val titles = listOf(
+            "01 - Posto 01 - Materiais",
+            "02 - POSTO - 02 OFICINA",
+            "03 - POSTO - 03 PRÉ-MONTAGEM - 01",
+            "04 - POSTO - 04 BARRAMENTO",
+            "05 - POSTO - 05 CABLAGEM - 01",
+            "06 - POSTO - 06 PRÉ-MONTAGEM - 02",
+            "06.1 - POSTO - 06 CABLAGEM - 02",
+            "07 - POSTO - 08 IQM",
+            "08 - POSTO - 08 IQE",
+            "POSTO - 08 TESTE",
+            "POSTO - 09 EXPEDIÇÃO"
+        )
+        val tabKeys = listOf<String?>(
+            null,
+            "pass_02",
+            "pass_03",
+            "pass_04",
+            "pass_05",
+            "pass_06",
+            "pass_06_1",
+            "pass_07",
+            "pass_08",
+            "pass_08_teste",
+            "pass_09"
+        )
 
         viewPager.adapter = object : FragmentStateAdapter(this) {
             override fun getItemCount(): Int = fragments.size
@@ -30,5 +104,41 @@ class MainActivity : AppCompatActivity() {
         TabLayoutMediator(tabLayout, viewPager) { tab, position ->
             tab.text = titles[position]
         }.attach()
+
+        viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                val key = tabKeys[position]
+                if (key != null) {
+                    val requiredPass = prefs.getString(key, "")
+                    if (!requiredPass.isNullOrEmpty()) {
+                        val input = EditText(this@MainActivity).apply {
+                            inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
+                        }
+                        AlertDialog.Builder(this@MainActivity)
+                            .setTitle("Senha necessária")
+                            .setView(input)
+                            .setPositiveButton("OK") { _, _ ->
+                                if (input.text.toString() == requiredPass) {
+                                    previousTab = position
+                                } else {
+                                    Toast.makeText(this@MainActivity, "Senha incorreta", Toast.LENGTH_SHORT).show()
+                                    viewPager.post { viewPager.currentItem = previousTab }
+                                }
+                            }
+                            .setNegativeButton("Cancelar") { _, _ ->
+                                viewPager.post { viewPager.currentItem = previousTab }
+                            }
+                            .setOnCancelListener {
+                                viewPager.post { viewPager.currentItem = previousTab }
+                            }
+                            .show()
+                    } else {
+                        previousTab = position
+                    }
+                } else {
+                    previousTab = position
+                }
+            }
+        })
     }
 }

--- a/AppOficina/app/src/main/java/com/example/appoficina/SimpleTextFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/SimpleTextFragment.kt
@@ -1,0 +1,31 @@
+package com.example.appoficina
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+
+class SimpleTextFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_simple_text, container, false)
+        val textView: TextView = view.findViewById(R.id.text_simple)
+        textView.text = arguments?.getString("text") ?: ""
+        return view
+    }
+
+    companion object {
+        fun newInstance(text: String): SimpleTextFragment {
+            val fragment = SimpleTextFragment()
+            fragment.arguments = Bundle().apply {
+                putString("text", text)
+            }
+            return fragment
+        }
+    }
+}

--- a/AppOficina/app/src/main/res/layout/activity_admin_config.xml
+++ b/AppOficina/app/src/main/res/layout/activity_admin_config.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <EditText
+            android:id="@+id/edit_admin_user"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Usuário admin" />
+
+        <EditText
+            android:id="@+id/edit_admin_pass"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Senha admin"
+            android:inputType="textPassword" />
+
+        <EditText
+            android:id="@+id/edit_pass_tab02"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Senha Posto 02" />
+
+        <EditText
+            android:id="@+id/edit_pass_tab03"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Senha Posto 03" />
+
+        <EditText
+            android:id="@+id/edit_pass_tab04"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Senha Posto 04" />
+
+        <EditText
+            android:id="@+id/edit_pass_tab05"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Senha Posto 05" />
+
+        <EditText
+            android:id="@+id/edit_pass_tab06"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Senha Posto 06" />
+
+        <EditText
+            android:id="@+id/edit_pass_tab06_1"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Senha Posto 06.1" />
+
+        <EditText
+            android:id="@+id/edit_pass_tab07"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Senha Posto 07" />
+
+        <EditText
+            android:id="@+id/edit_pass_tab08"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Senha Posto 08 IQE" />
+
+        <EditText
+            android:id="@+id/edit_pass_tab08_teste"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Senha Posto 08 Teste" />
+
+        <EditText
+            android:id="@+id/edit_pass_tab09"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Senha Posto 09" />
+
+        <Button
+            android:id="@+id/button_save"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Salvar" />
+    </LinearLayout>
+</ScrollView>

--- a/AppOficina/app/src/main/res/layout/activity_main.xml
+++ b/AppOficina/app/src/main/res/layout/activity_main.xml
@@ -5,6 +5,12 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
+    <Button
+        android:id="@+id/admin_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/app_name" />
+
     <com.google.android.material.tabs.TabLayout
         android:id="@+id/tab_layout"
         android:layout_width="match_parent"

--- a/AppOficina/app/src/main/res/layout/fragment_simple_text.xml
+++ b/AppOficina/app/src/main/res/layout/fragment_simple_text.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/text_simple"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
+</FrameLayout>


### PR DESCRIPTION
## Summary
- add tabs for postos 03 to 09 and simple text fragments
- allow admin login via AppOficina button and configure passwords per tab
- include admin settings screen to manage credentials

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6897e139c9d8832f904fe2cd1200c096