### PR TITLE
Avoid crash when fragment is detached

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/Posto01MateriaisFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/Posto01MateriaisFragment.kt
@@ -39,7 +39,8 @@ class Posto01MateriaisFragment : Fragment() {
                     conn.disconnect()
 
                     val projetos = JSONObject(response).optJSONArray("projetos") ?: JSONArray()
-                    requireActivity().runOnUiThread {
+                    if (!isAdded) return@Thread
+                    activity?.runOnUiThread {
                         listContainer.removeAllViews()
                         for (i in 0 until projetos.length()) {
                             val obj = projetos.getJSONObject(i)
@@ -73,8 +74,8 @@ class Posto01MateriaisFragment : Fragment() {
                     // tenta proximo endereco
                 }
             }
-            if (!loaded) {
-                requireActivity().runOnUiThread {
+            if (!loaded && isAdded) {
+                activity?.runOnUiThread {
                     listContainer.removeAllViews()
                     val tv = TextView(requireContext())
                     tv.text = "Não foi possível carregar os projetos"


### PR DESCRIPTION
## Summary
- Avoid IllegalStateException by checking `isAdded` before updating UI in `Posto01MateriaisFragment`

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6897fceba7d4832fb69cead0273d9eee