### PR TITLE
Add N.A option to checklists

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Activity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Activity.kt
@@ -51,15 +51,36 @@ class ChecklistPosto01Activity : AppCompatActivity() {
         val typeMateriais = Types.newParameterizedType(List::class.java, ChecklistMaterial::class.java)
         val materiais = moshi.adapter<List<ChecklistMaterial>>(typeMateriais).fromJson(jsonMateriais) ?: emptyList()
 
-        val pairs = (1..54).map { i ->
+        val triplets = (1..54).map { i ->
             val c = resources.getIdentifier("cbQ${i}C", "id", packageName)
             val nc = resources.getIdentifier("cbQ${i}NC", "id", packageName)
-            findViewById<CheckBox>(c) to findViewById<CheckBox>(nc)
+            val na = resources.getIdentifier("cbQ${i}NA", "id", packageName)
+            Triple(
+                findViewById<CheckBox>(c),
+                findViewById<CheckBox>(nc),
+                findViewById<CheckBox>(na),
+            )
         }
 
-        pairs.forEach { (cbC, cbNC) ->
-            cbC.setOnCheckedChangeListener { _, isChecked -> if (isChecked) cbNC.isChecked = false }
-            cbNC.setOnCheckedChangeListener { _, isChecked -> if (isChecked) cbC.isChecked = false }
+        triplets.forEach { (cbC, cbNC, cbNA) ->
+            cbC.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    cbNC.isChecked = false
+                    cbNA.isChecked = false
+                }
+            }
+            cbNC.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    cbC.isChecked = false
+                    cbNA.isChecked = false
+                }
+            }
+            cbNA.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    cbC.isChecked = false
+                    cbNC.isChecked = false
+                }
+            }
         }
 
         val questions = listOf(
@@ -120,10 +141,11 @@ class ChecklistPosto01Activity : AppCompatActivity() {
         )
 
         findViewById<Button>(R.id.btnConcluirPosto01).setOnClickListener {
-            val respostas = pairs.mapIndexed { index, (cbC, cbNC) ->
+            val respostas = triplets.mapIndexed { index, (cbC, cbNC, cbNA) ->
                 val marcados = mutableListOf<String>()
                 if (cbC.isChecked) marcados.add("C")
                 if (cbNC.isChecked) marcados.add("NC")
+                if (cbNA.isChecked) marcados.add("NA")
                 if (marcados.isEmpty()) {
                     Toast.makeText(this, "Selecione uma opção em: ${questions[index]}", Toast.LENGTH_SHORT).show()
                     return@setOnClickListener

--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Parte2Activity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Parte2Activity.kt
@@ -48,15 +48,36 @@ class ChecklistPosto01Parte2Activity : AppCompatActivity() {
         val typeMateriais = Types.newParameterizedType(List::class.java, ChecklistMaterial::class.java)
         val materiais = moshi.adapter<List<ChecklistMaterial>>(typeMateriais).fromJson(jsonMateriais) ?: emptyList()
 
-        val pairs = (55..74).map { i ->
+        val triplets = (55..74).map { i ->
             val c = resources.getIdentifier("cbQ${i}C", "id", packageName)
             val nc = resources.getIdentifier("cbQ${i}NC", "id", packageName)
-            findViewById<CheckBox>(c) to findViewById<CheckBox>(nc)
+            val na = resources.getIdentifier("cbQ${i}NA", "id", packageName)
+            Triple(
+                findViewById<CheckBox>(c),
+                findViewById<CheckBox>(nc),
+                findViewById<CheckBox>(na),
+            )
         }
 
-        pairs.forEach { (cbC, cbNC) ->
-            cbC.setOnCheckedChangeListener { _, isChecked -> if (isChecked) cbNC.isChecked = false }
-            cbNC.setOnCheckedChangeListener { _, isChecked -> if (isChecked) cbC.isChecked = false }
+        triplets.forEach { (cbC, cbNC, cbNA) ->
+            cbC.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    cbNC.isChecked = false
+                    cbNA.isChecked = false
+                }
+            }
+            cbNC.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    cbC.isChecked = false
+                    cbNA.isChecked = false
+                }
+            }
+            cbNA.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    cbC.isChecked = false
+                    cbNC.isChecked = false
+                }
+            }
         }
 
         val questions = listOf(
@@ -83,10 +104,11 @@ class ChecklistPosto01Parte2Activity : AppCompatActivity() {
         )
 
         findViewById<Button>(R.id.btnConcluirPosto01Parte2).setOnClickListener {
-            val respostas = pairs.mapIndexed { index, (cbC, cbNC) ->
+            val respostas = triplets.mapIndexed { index, (cbC, cbNC, cbNA) ->
                 val marcados = mutableListOf<String>()
                 if (cbC.isChecked) marcados.add("C")
                 if (cbNC.isChecked) marcados.add("NC")
+                if (cbNA.isChecked) marcados.add("NA")
                 if (marcados.isEmpty()) {
                     Toast.makeText(this, "Selecione uma opção em: ${questions[index]}", Toast.LENGTH_SHORT).show()
                     return@setOnClickListener

--- a/AppEstoque/app/src/main/res/layout/activity_checklist_posto01.xml
+++ b/AppEstoque/app/src/main/res/layout/activity_checklist_posto01.xml
@@ -41,6 +41,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ1NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -62,6 +68,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ2NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -85,6 +97,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ3NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -106,6 +124,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ4NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -136,6 +160,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ5NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -157,6 +187,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ6NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -180,6 +216,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ7NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -201,6 +243,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ8NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -231,6 +279,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ9NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -252,6 +306,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ10NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -275,6 +335,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ11NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -296,6 +362,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ12NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -326,6 +398,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ13NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -347,6 +425,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ14NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -370,6 +454,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ15NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -391,6 +481,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ16NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -421,6 +517,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ17NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -442,6 +544,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ18NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -465,6 +573,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ19NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -486,6 +600,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ20NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -516,6 +636,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ21NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -537,6 +663,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ22NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -560,6 +692,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ23NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -581,6 +719,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ24NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -611,6 +755,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ25NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -632,6 +782,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ26NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -655,6 +811,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ27NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -676,6 +838,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ28NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -706,6 +874,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ29NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -727,6 +901,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ30NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -750,6 +930,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ31NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -771,6 +957,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ32NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -801,6 +993,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ33NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -822,6 +1020,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ34NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -845,6 +1049,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ35NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -866,6 +1076,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ36NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -896,6 +1112,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ37NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -917,6 +1139,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ38NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -940,6 +1168,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ39NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -961,6 +1195,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ40NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -991,6 +1231,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ41NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -1012,6 +1258,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ42NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -1035,6 +1287,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ43NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -1056,6 +1314,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ44NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -1086,6 +1350,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ45NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -1107,6 +1377,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ46NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -1130,6 +1406,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ47NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -1151,6 +1433,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ48NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -1181,6 +1469,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ49NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -1202,6 +1496,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ50NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -1225,6 +1525,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ51NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -1246,6 +1552,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ52NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -1276,6 +1588,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ53NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -1297,6 +1615,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ54NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 

--- a/AppEstoque/app/src/main/res/layout/activity_checklist_posto01_parte2.xml
+++ b/AppEstoque/app/src/main/res/layout/activity_checklist_posto01_parte2.xml
@@ -36,6 +36,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ55NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -57,6 +63,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ56NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -80,6 +92,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ57NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -101,6 +119,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ58NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -132,6 +156,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ59NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -153,6 +183,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ60NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -176,6 +212,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ61NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -197,6 +239,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ62NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -228,6 +276,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ63NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -249,6 +303,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ64NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -272,6 +332,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ65NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -293,6 +359,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ66NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -324,6 +396,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ67NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -345,6 +423,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ68NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -368,6 +452,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ69NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -389,6 +479,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ70NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -420,6 +516,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ71NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -441,6 +543,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ72NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -464,6 +572,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ73NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -485,6 +599,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ74NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto01Parte2Activity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto01Parte2Activity.kt
@@ -19,25 +19,45 @@ class ChecklistPosto01Parte2Activity : AppCompatActivity() {
         val ano = intent.getStringExtra("ano") ?: ""
         val producao = intent.getStringExtra("producao") ?: ""
 
-        val pairs = (55..74).map { i ->
+        val triplets = (55..74).map { i ->
             val cId = resources.getIdentifier("cbQ${i}C", "id", packageName)
             val ncId = resources.getIdentifier("cbQ${i}NC", "id", packageName)
-            findViewById<CheckBox>(cId) to findViewById<CheckBox>(ncId)
+            val naId = resources.getIdentifier("cbQ${i}NA", "id", packageName)
+            Triple(
+                findViewById<CheckBox>(cId),
+                findViewById<CheckBox>(ncId),
+                findViewById<CheckBox>(naId),
+            )
         }
 
         val concluirButton = findViewById<Button>(R.id.btnConcluirPosto01Parte2)
 
         fun updateButtonState() {
-            concluirButton.isEnabled = pairs.all { (c, nc) -> c.isChecked || nc.isChecked }
+            concluirButton.isEnabled = triplets.all { (c, nc, na) ->
+                c.isChecked || nc.isChecked || na.isChecked
+            }
         }
 
-        pairs.forEach { (c, nc) ->
+        triplets.forEach { (c, nc, na) ->
             c.setOnCheckedChangeListener { _, isChecked ->
-                if (isChecked) nc.isChecked = false
+                if (isChecked) {
+                    nc.isChecked = false
+                    na.isChecked = false
+                }
                 updateButtonState()
             }
             nc.setOnCheckedChangeListener { _, isChecked ->
-                if (isChecked) c.isChecked = false
+                if (isChecked) {
+                    c.isChecked = false
+                    na.isChecked = false
+                }
+                updateButtonState()
+            }
+            na.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    c.isChecked = false
+                    nc.isChecked = false
+                }
                 updateButtonState()
             }
         }
@@ -69,7 +89,7 @@ class ChecklistPosto01Parte2Activity : AppCompatActivity() {
 
         concluirButton.setOnClickListener {
             val itens = JSONArray()
-            pairs.forEachIndexed { idx, (c, nc) ->
+            triplets.forEachIndexed { idx, (c, nc, na) ->
                 val obj = JSONObject()
                 obj.put("numero", 55 + idx)
                 obj.put("pergunta", perguntas[idx])
@@ -78,6 +98,7 @@ class ChecklistPosto01Parte2Activity : AppCompatActivity() {
                     when {
                         c.isChecked -> "C"
                         nc.isChecked -> "NC"
+                        na.isChecked -> "NA"
                         else -> ""
                     }
                 )

--- a/AppOficina/app/src/main/res/layout/activity_checklist_posto01_parte2.xml
+++ b/AppOficina/app/src/main/res/layout/activity_checklist_posto01_parte2.xml
@@ -36,6 +36,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ55NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -57,6 +63,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ56NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -80,6 +92,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ57NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -101,6 +119,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ58NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -132,6 +156,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ59NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -153,6 +183,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ60NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -176,6 +212,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ61NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -197,6 +239,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ62NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -228,6 +276,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ63NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -249,6 +303,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ64NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -272,6 +332,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ65NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -293,6 +359,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ66NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -324,6 +396,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ67NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -345,6 +423,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ68NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -368,6 +452,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ69NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -389,6 +479,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ70NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -420,6 +516,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ71NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -441,6 +543,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ72NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 
@@ -464,6 +572,12 @@
                 android:layout_height="wrap_content"
                 android:text="N.C"
                 android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ73NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
+                android:layout_marginStart="24dp" />
         </LinearLayout>
 
         <TextView
@@ -485,6 +599,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="N.C"
+                android:layout_marginStart="24dp" />
+            <CheckBox
+                android:id="@+id/cbQ74NA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="N.A"
                 android:layout_marginStart="24dp" />
         </LinearLayout>
 


### PR DESCRIPTION
## Summary
- support a third "N.A" (não se aplica) option in AppEstoque checklists
- add "N.A" option and logic to AppOficina checklist
- extend checklist layouts to include the new choice

## Testing
- `bash ./gradlew test` (AppEstoque) *(failed: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*
- `bash ./gradlew test` (AppOficina) *(failed: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_6898074df85c832f96b3f8c654d5721f