### PR TITLE
Add checklist merging utility

### DIFF
--- a/site/json_api/Posto01_Oficina/checklist_PRO200.json
+++ b/site/json_api/Posto01_Oficina/checklist_PRO200.json
@@ -1,0 +1,797 @@
+{
+  "obra": "PRO200",
+  "ano": "2025",
+  "respondentes": {
+    "suprimento": "",
+    "produção": "muri"
+  },
+  "itens": [
+    {
+      "numero": 1,
+      "pergunta": "1.2 - INVÓLUCRO - CAIXA: Identificação do projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 2,
+      "pergunta": "1.2 - INVÓLUCRO - CAIXA: Separação - POSTO - 07",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 3,
+      "pergunta": "1.2 - INVÓLUCRO - CAIXA: Referências x Projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 4,
+      "pergunta": "1.2 - INVÓLUCRO - CAIXA: Material em bom estado",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 5,
+      "pergunta": "1.3 - INVÓLUCRO - AUTOPORTANTE: Identificação do projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 6,
+      "pergunta": "1.3 - INVÓLUCRO - AUTOPORTANTE: Separação - POSTO - 07",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 7,
+      "pergunta": "1.3 - INVÓLUCRO - AUTOPORTANTE: Referências x Projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 8,
+      "pergunta": "1.3 - INVÓLUCRO - AUTOPORTANTE: Material em bom estado",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 9,
+      "pergunta": "1.4 - INVÓLUCRO - PLACAS DE MONTAGEM: Identificação do projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 10,
+      "pergunta": "1.4 - INVÓLUCRO - PLACAS DE MONTAGEM: Separação - POSTO - 07",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 11,
+      "pergunta": "1.4 - INVÓLUCRO - PLACAS DE MONTAGEM: Referências x Projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 12,
+      "pergunta": "1.4 - INVÓLUCRO - PLACAS DE MONTAGEM: Material em bom estado",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 13,
+      "pergunta": "1.5 - INVÓLUCRO - FLANGES: Identificação do projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 14,
+      "pergunta": "1.5 - INVÓLUCRO - FLANGES: Separação - POSTO - 07",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 15,
+      "pergunta": "1.5 - INVÓLUCRO - FLANGES: Referências x Projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 16,
+      "pergunta": "1.5 - INVÓLUCRO - FLANGES: Material em bom estado",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 17,
+      "pergunta": "1.6 - INVÓLUCRO - PORTAS COM RECORTE: Identificação do projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 18,
+      "pergunta": "1.6 - INVÓLUCRO - PORTAS COM RECORTE: Separação - POSTO - 07",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 19,
+      "pergunta": "1.6 - INVÓLUCRO - PORTAS COM RECORTE: Referências x Projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 20,
+      "pergunta": "1.6 - INVÓLUCRO - PORTAS COM RECORTE: Material em bom estado",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 21,
+      "pergunta": "1.8 - INVÓLUCRO - CONTRAPORTAS COM RECORTE: Identificação do projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 22,
+      "pergunta": "1.8 - INVÓLUCRO - CONTRAPORTAS COM RECORTE: Separação - POSTO - 07",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 23,
+      "pergunta": "1.8 - INVÓLUCRO - CONTRAPORTAS COM RECORTE: Referências x Projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 24,
+      "pergunta": "1.8 - INVÓLUCRO - CONTRAPORTAS COM RECORTE: Material em bom estado",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 25,
+      "pergunta": "1.11 - CABOS: Identificação do projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 26,
+      "pergunta": "1.11 - CABOS: Separação - POSTO - 01",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 27,
+      "pergunta": "1.11 - CABOS: Referências x Projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 28,
+      "pergunta": "1.11 - CABOS: Material em bom estado",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 29,
+      "pergunta": "1.12 - BARRAMENTO: Identificação do projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 30,
+      "pergunta": "1.12 - BARRAMENTO: Separação - POSTO - 04",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 31,
+      "pergunta": "1.12 - BARRAMENTO: Referências x Projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 32,
+      "pergunta": "1.12 - BARRAMENTO: Material em bom estado",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 33,
+      "pergunta": "1.13 - TRILHOS: Identificação do projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 34,
+      "pergunta": "1.13 - TRILHOS: Separação - POSTO - 03",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 35,
+      "pergunta": "1.13 - TRILHOS: Referências x Projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 36,
+      "pergunta": "1.13 - TRILHOS: Material em bom estado",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 37,
+      "pergunta": "1.14 - CANALETAS: Identificação do projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 38,
+      "pergunta": "1.14 - CANALETAS: Separação - POSTO - 03",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 39,
+      "pergunta": "1.14 - CANALETAS: Referências x Projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 40,
+      "pergunta": "1.14 - CANALETAS: Material em bom estado",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 41,
+      "pergunta": "1.16 - ETIQUETAS: Identificação do projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 42,
+      "pergunta": "1.16 - ETIQUETAS: Separação - POSTO - 01",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 43,
+      "pergunta": "1.16 - ETIQUETAS: Referências x Projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 44,
+      "pergunta": "1.16 - ETIQUETAS: Material em bom estado",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 45,
+      "pergunta": "1.17 - PARAFUSOS/PORCAS/ARRUELAS: Identificação do projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 46,
+      "pergunta": "1.17 - PARAFUSOS/PORCAS/ARRUELAS: Separação - POSTO - 01",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 47,
+      "pergunta": "1.17 - PARAFUSOS/PORCAS/ARRUELAS: Referências x Projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 48,
+      "pergunta": "1.17 - PARAFUSOS/PORCAS/ARRUELAS: Material em bom estado",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 49,
+      "pergunta": "1.18 - ISOLADORES: Identificação do projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 50,
+      "pergunta": "1.18 - ISOLADORES: Separação - POSTO - 01",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 51,
+      "pergunta": "1.18 - ISOLADORES: Referências x Projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 52,
+      "pergunta": "1.18 - ISOLADORES: Material em bom estado",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 53,
+      "pergunta": "1.19 - PALETIZAÇÃO: Fabricação do palete",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 54,
+      "pergunta": "1.19 - PALETIZAÇÃO: Fixação no invólucro",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": null
+      }
+    },
+    {
+      "numero": 55,
+      "pergunta": "1.1 - COMPONENTES: Identificação do projeto",
+      "respostas": {
+        "suprimento": [
+          "NC"
+        ],
+        "produção": [
+          ""
+        ]
+      }
+    },
+    {
+      "numero": 56,
+      "pergunta": "1.1 - COMPONENTES: Separação - POSTO - 01",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": [
+          ""
+        ]
+      }
+    },
+    {
+      "numero": 57,
+      "pergunta": "1.1 - COMPONENTES: Referências x Projeto",
+      "respostas": {
+        "suprimento": [
+          "NC"
+        ],
+        "produção": [
+          ""
+        ]
+      }
+    },
+    {
+      "numero": 58,
+      "pergunta": "1.1 - COMPONENTES: Material em bom estado",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": [
+          ""
+        ]
+      }
+    },
+    {
+      "numero": 59,
+      "pergunta": "1.7 - INVÓLUCRO - PORTAS SEM RECORTE: Identificação do projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": [
+          ""
+        ]
+      }
+    },
+    {
+      "numero": 60,
+      "pergunta": "1.7 - INVÓLUCRO - PORTAS SEM RECORTE: Separação - POSTO - 07",
+      "respostas": {
+        "suprimento": [
+          "NC"
+        ],
+        "produção": [
+          ""
+        ]
+      }
+    },
+    {
+      "numero": 61,
+      "pergunta": "1.7 - INVÓLUCRO - PORTAS SEM RECORTE: Referências x Projeto",
+      "respostas": {
+        "suprimento": [
+          "NC"
+        ],
+        "produção": [
+          ""
+        ]
+      }
+    },
+    {
+      "numero": 62,
+      "pergunta": "1.7 - INVÓLUCRO - PORTAS SEM RECORTE: Material em bom estado",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": [
+          ""
+        ]
+      }
+    },
+    {
+      "numero": 63,
+      "pergunta": "1.9 - INVÓLUCRO - CONTRAPORTAS SEM RECORTE: Identificação do projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": [
+          ""
+        ]
+      }
+    },
+    {
+      "numero": 64,
+      "pergunta": "1.9 - INVÓLUCRO - CONTRAPORTAS SEM RECORTE: Separação - POSTO - 07",
+      "respostas": {
+        "suprimento": [
+          "NC"
+        ],
+        "produção": [
+          ""
+        ]
+      }
+    },
+    {
+      "numero": 65,
+      "pergunta": "1.9 - INVÓLUCRO - CONTRAPORTAS SEM RECORTE: Referências x Projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": [
+          ""
+        ]
+      }
+    },
+    {
+      "numero": 66,
+      "pergunta": "1.9 - INVÓLUCRO - CONTRAPORTAS SEM RECORTE: Material em bom estado",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": [
+          ""
+        ]
+      }
+    },
+    {
+      "numero": 67,
+      "pergunta": "1.10 - INVÓLUCRO - FECHAMENTOS LATERAIS E TRASEIRO: Identificação do projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": [
+          ""
+        ]
+      }
+    },
+    {
+      "numero": 68,
+      "pergunta": "1.10 - INVÓLUCRO - FECHAMENTOS LATERAIS E TRASEIRO: Separação - POSTO - 07",
+      "respostas": {
+        "suprimento": [
+          "NC"
+        ],
+        "produção": [
+          ""
+        ]
+      }
+    },
+    {
+      "numero": 69,
+      "pergunta": "1.10 - INVÓLUCRO - FECHAMENTOS LATERAIS E TRASEIRO: Referências x Projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": [
+          ""
+        ]
+      }
+    },
+    {
+      "numero": 70,
+      "pergunta": "1.10 - INVÓLUCRO - FECHAMENTOS LATERAIS E TRASEIRO: Material em bom estado",
+      "respostas": {
+        "suprimento": [
+          "NC"
+        ],
+        "produção": [
+          ""
+        ]
+      }
+    },
+    {
+      "numero": 71,
+      "pergunta": "1.15 - POLICARBONATO: Identificação do projeto",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": [
+          ""
+        ]
+      }
+    },
+    {
+      "numero": 72,
+      "pergunta": "1.15 - POLICARBONATO: Separação - POSTO - 03",
+      "respostas": {
+        "suprimento": [
+          "NC"
+        ],
+        "produção": [
+          ""
+        ]
+      }
+    },
+    {
+      "numero": 73,
+      "pergunta": "1.15 - POLICARBONATO: Referências x Projeto",
+      "respostas": {
+        "suprimento": [
+          "NC"
+        ],
+        "produção": [
+          ""
+        ]
+      }
+    },
+    {
+      "numero": 74,
+      "pergunta": "1.15 - POLICARBONATO: Material em bom estado",
+      "respostas": {
+        "suprimento": [
+          "C"
+        ],
+        "produção": [
+          ""
+        ]
+      }
+    }
+  ],
+  "materiais": [
+    {
+      "material": "ASDASDSDASD",
+      "quantidade": 2,
+      "completo": true
+    }
+  ]
+}

--- a/site/json_api/__init__.py
+++ b/site/json_api/__init__.py
@@ -49,3 +49,6 @@ def listar_projetos():
 # legacy alias
 bp.add_url_rule('/upload', view_func=salvar_checklist, methods=['POST'])
 
+# utilidades de mesclagem
+from .merge_checklists import merge_checklists, merge_directory
+

--- a/site/json_api/merge_checklists.py
+++ b/site/json_api/merge_checklists.py
@@ -1,0 +1,118 @@
+import os
+import json
+from typing import Any, Dict, List, Optional
+
+
+def merge_checklists(json_suprimento: Dict[str, Any], json_producao: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge two checklist JSON structures according to business rules."""
+    obra_sup = json_suprimento.get("obra", "")
+    obra_prod = json_producao.get("obra", "")
+    ano_sup = json_suprimento.get("ano", "")
+    ano_prod = json_producao.get("ano", "")
+
+    obra = obra_sup or obra_prod
+    ano = ano_sup or ano_prod
+
+    avisos: List[str] = []
+    if obra_sup and obra_prod and obra_sup != obra_prod:
+        avisos.append(f"Divergência de obra: suprimento={obra_sup}, produção={obra_prod}")
+    if ano_sup and ano_prod and ano_sup != ano_prod:
+        avisos.append(f"Divergência de ano: suprimento={ano_sup}, produção={ano_prod}")
+
+    result: Dict[str, Any] = {
+        "obra": obra,
+        "ano": ano,
+        "respondentes": {
+            "suprimento": json_suprimento.get("suprimento"),
+            "produção": json_producao.get("produção"),
+        },
+    }
+
+    itens: Dict[int, Dict[str, Any]] = {}
+    for item in json_suprimento.get("itens", []):
+        numero = item.get("numero")
+        if numero is None:
+            continue
+        pergunta = item.get("pergunta", "")
+        resposta = item.get("resposta")
+        itens.setdefault(numero, {})["pergunta_sup"] = pergunta
+        itens[numero]["res_sup"] = resposta if isinstance(resposta, list) else None
+    for item in json_producao.get("itens", []):
+        numero = item.get("numero")
+        if numero is None:
+            continue
+        pergunta = item.get("pergunta", "")
+        resposta = item.get("resposta")
+        entry = itens.setdefault(numero, {})
+        entry["pergunta_prod"] = pergunta
+        entry["res_prod"] = resposta if isinstance(resposta, list) else None
+
+    result_items: List[Dict[str, Any]] = []
+    for numero in sorted(itens):
+        entry = itens[numero]
+        pergunta_sup = entry.get("pergunta_sup", "")
+        pergunta_prod = entry.get("pergunta_prod", "")
+        pergunta = pergunta_sup if len(pergunta_sup) >= len(pergunta_prod) else pergunta_prod
+        result_items.append(
+            {
+                "numero": numero,
+                "pergunta": pergunta or pergunta_prod or pergunta_sup,
+                "respostas": {
+                    "suprimento": entry.get("res_sup"),
+                    "produção": entry.get("res_prod"),
+                },
+            }
+        )
+    result["itens"] = result_items
+
+    materiais: Dict[str, Dict[str, Any]] = {}
+    for mat in json_suprimento.get("materiais", []) + json_producao.get("materiais", []):
+        nome = mat.get("material")
+        if not nome:
+            continue
+        quantidade = mat.get("quantidade", 0) or 0
+        completo = bool(mat.get("completo"))
+        registro = materiais.setdefault(nome, {"material": nome, "quantidade": 0, "completo": True})
+        registro["quantidade"] += quantidade
+        registro["completo"] = registro["completo"] and completo
+    result["materiais"] = list(materiais.values()) if materiais else []
+
+    if avisos:
+        result["avisos"] = avisos
+
+    return result
+
+
+def merge_directory(base_dir: str, output_dir: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Merge checklist pairs found in ``base_dir`` grouped by ``obra``.
+
+    ``output_dir`` defaults to ``base_dir/Posto01_Oficina``.
+    Returns a list of merged checklist objects.
+    """
+    files = [f for f in os.listdir(base_dir) if f.endswith(".json")]
+    by_obra: Dict[str, List[Dict[str, Any]]] = {}
+    for fname in files:
+        path = os.path.join(base_dir, fname)
+        try:
+            with open(path, "r", encoding="utf-8") as fp:
+                data = json.load(fp)
+        except Exception:
+            continue
+        obra = data.get("obra")
+        if not obra:
+            continue
+        by_obra.setdefault(obra, []).append(data)
+    output_dir = output_dir or os.path.join(base_dir, "Posto01_Oficina")
+    os.makedirs(output_dir, exist_ok=True)
+    merged: List[Dict[str, Any]] = []
+    for obra, entries in by_obra.items():
+        sup = next((e for e in entries if "suprimento" in e), None)
+        prod = next((e for e in entries if "produção" in e), None)
+        if not (sup and prod):
+            continue
+        result = merge_checklists(sup, prod)
+        out_path = os.path.join(output_dir, f"checklist_{obra}.json")
+        with open(out_path, "w", encoding="utf-8") as fp:
+            json.dump(result, fp, ensure_ascii=False, indent=2)
+        merged.append(result)
+    return merged


### PR DESCRIPTION
## Summary
- add helper to merge supply and production checklist JSONs
- expose merge helpers from json_api module
- include merged sample checklist for PRO200

## Testing
- `python -m py_compile json_api/merge_checklists.py json_api/__init__.py`
- `python - <<'PY'
import json
from json_api.merge_checklists import merge_directory
merged = merge_directory('json_api')
print(len(merged))
for m in merged:
    print(m['obra'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_6898143b50a8832f9be8d7520d170029