### PR TITLE
feat: promote completed checklists and expose Posto02

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/Posto02OficinaFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/Posto02OficinaFragment.kt
@@ -26,9 +26,9 @@ class Posto02OficinaFragment : Fragment() {
 
         Thread {
             val urls = listOf(
-                "http://10.0.2.2:5000/json_api/projects",
-                "http://192.168.0.151:5000/json_api/projects",
-                "http://192.168.0.135:5000/json_api/projects",
+                "http://10.0.2.2:5000/json_api/posto02/projects",
+                "http://192.168.0.151:5000/json_api/posto02/projects",
+                "http://192.168.0.135:5000/json_api/posto02/projects",
             )
             var loaded = false
             for (address in urls) {

--- a/site/app.py
+++ b/site/app.py
@@ -5,7 +5,7 @@ from models import db, User, AuthorizedIP, ITEM_STATUS_OPTIONS
 from projetista import bp as projetista_bp
 from compras import bp as compras_bp
 from auth import bp as auth_bp
-from json_api import bp as json_api_bp, merge_directory
+from json_api import bp as json_api_bp, merge_directory, move_matching_checklists
 from flask_login import LoginManager, login_user, current_user
 from flask import Flask, request
 from sqlalchemy import inspect
@@ -47,7 +47,9 @@ def create_app():
     app.register_blueprint(compras_bp, url_prefix='/compras')
     app.register_blueprint(json_api_bp, url_prefix='/json_api')
     app.register_blueprint(auth_bp)
-    merge_directory(os.path.join(os.path.dirname(__file__), 'json_api'))
+    base_json = os.path.join(os.path.dirname(__file__), 'json_api')
+    merge_directory(base_json)
+    move_matching_checklists(base_json)
 
     with app.app_context():
         db.create_all()

--- a/site/json_api/__init__.py
+++ b/site/json_api/__init__.py
@@ -24,6 +24,7 @@ def salvar_checklist():
     with open(file_path, 'w', encoding='utf-8') as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
     merge_directory(BASE_DIR)
+    move_matching_checklists(BASE_DIR)
 
     return jsonify({'caminho': file_path})
 
@@ -42,6 +43,29 @@ def listar_projetos():
                 'arquivo': nome,
                 'obra': data.get('obra', path.splitext(nome)[0]),
                 'ano': data.get('ano', '')
+            })
+        except Exception:
+            continue
+    return jsonify({'projetos': projetos})
+
+
+@bp.route('/posto02/projects', methods=['GET'])
+def listar_posto02_projetos():
+    """Return obra/ano info for each checklist JSON file in Posto02_Oficina."""
+    dir_path = os.path.join(BASE_DIR, 'Posto02_Oficina')
+    if not os.path.isdir(dir_path):
+        return jsonify({'projetos': []})
+    arquivos = [f for f in os.listdir(dir_path) if f.endswith('.json')]
+    projetos = []
+    for nome in sorted(arquivos):
+        caminho = path.join(dir_path, nome)
+        try:
+            with open(caminho, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            projetos.append({
+                'arquivo': nome,
+                'obra': data.get('obra', path.splitext(nome)[0]),
+                'ano': data.get('ano', ''),
             })
         except Exception:
             continue
@@ -110,3 +134,4 @@ bp.add_url_rule('/upload', view_func=salvar_checklist, methods=['POST'])
 
 # utilidades de mesclagem
 from .merge_checklists import merge_checklists, merge_directory, find_mismatches
+from .merge_checklists import move_matching_checklists


### PR DESCRIPTION
## Summary
- promote merged checklists with matching answers from Posto01_Oficina to Posto02_Oficina
- add API endpoint listing Posto02 checklists and update Android fragment URLs
- run merge/move on startup

## Testing
- `python -m py_compile site/json_api/merge_checklists.py site/json_api/__init__.py site/app.py`
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68992b3c83f4832f9c61f9f4a5756f42