### PR TITLE
Add Posto03 Pre-montagem workflow

### DIFF
--- a/AppOficina/app/src/main/AndroidManifest.xml
+++ b/AppOficina/app/src/main/AndroidManifest.xml
@@ -26,6 +26,8 @@
         <activity android:name=".ChecklistPosto01Parte2Activity" android:exported="false" />
         <activity android:name=".ChecklistPosto02Activity" android:exported="false" />
         <activity android:name=".ChecklistPosto02InspActivity" android:exported="false" />
+        <activity android:name=".ChecklistPosto03PreActivity" android:exported="false" />
+        <activity android:name=".ChecklistPosto03PreInspActivity" android:exported="false" />
         <activity android:name=".PreviewDivergenciasActivity" android:exported="false" />
         <activity android:name=".AdminConfigActivity" android:exported="false" />
         <activity android:name=".InspetorActivity" android:exported="false" />

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto03PreActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto03PreActivity.kt
@@ -1,0 +1,153 @@
+package com.example.appoficina
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.CheckBox
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
+
+class ChecklistPosto03PreActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_checklist_posto03_pre_montagem_01)
+
+        val obra = intent.getStringExtra("obra") ?: ""
+        val ano = intent.getStringExtra("ano") ?: ""
+        val montador = intent.getStringExtra("montador") ?: ""
+
+        val perguntas = listOf(
+            "3.1 - COMPONENTES: Montagem",
+            "3.1 - COMPONENTES: Montagem de acessórios",
+            "3.1 - COMPONENTES: Identificação",
+            "3.2 - RÉGUAS DE BORNES: Montagem",
+            "3.2 - RÉGUAS DE BORNES: Montagem de acessórios",
+            "3.2 - RÉGUAS DE BORNES: Identificação",
+            "3.3 - BARRAMENTO FRONTAL: Montagem",
+            "3.3 - BARRAMENTO FRONTAL: Parafusos/ Porcas/ Arruelas - Campo",
+            "3.3 - BARRAMENTO FRONTAL: Fabricação de anteparos em policarbonato",
+            "3.3 - BARRAMENTO FRONTAL: Colagem etiquetas dos anteparos",
+            "3.3 - BARRAMENTO FRONTAL: Identificação por projeto de anteparos",
+            "3.3 - BARRAMENTO FRONTAL: Separação de anteparos do barramento POSTO - 07",
+            "3.4 - PORTA: Nome do painel",
+            "3.4 - PORTA: Etiqueta de dados",
+            "3.4 - PORTA: Etiqueta de advertencia",
+            "3.4 - PORTA: Etiquetas externas dispositivos",
+            "3.4 - PORTA: Etiqueta de circuitos",
+            "3.4 - PORTA: Etiqueta de componentes",
+        )
+
+        val container = findViewById<LinearLayout>(R.id.questions_container)
+        val triplets = mutableListOf<Triple<CheckBox, CheckBox, CheckBox>>()
+
+        perguntas.forEach { pergunta ->
+            val tv = TextView(this)
+            tv.text = pergunta
+            container.addView(tv)
+            val row = LinearLayout(this)
+            row.orientation = LinearLayout.HORIZONTAL
+            val c = CheckBox(this)
+            c.text = "C"
+            val nc = CheckBox(this)
+            nc.text = "N.C"
+            nc.setPadding(24, 0, 0, 0)
+            val na = CheckBox(this)
+            na.text = "N.A"
+            na.setPadding(24, 0, 0, 0)
+            row.addView(c)
+            row.addView(nc)
+            row.addView(na)
+            container.addView(row)
+            triplets.add(Triple(c, nc, na))
+        }
+
+        val concluirButton = findViewById<Button>(R.id.btnConcluirPosto03Pre)
+
+        fun updateButtonState() {
+            concluirButton.isEnabled = triplets.all { (c, nc, na) ->
+                c.isChecked || nc.isChecked || na.isChecked
+            }
+        }
+
+        triplets.forEach { (c, nc, na) ->
+            c.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    nc.isChecked = false
+                    na.isChecked = false
+                }
+                updateButtonState()
+            }
+            nc.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    c.isChecked = false
+                    na.isChecked = false
+                }
+                updateButtonState()
+            }
+            na.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    c.isChecked = false
+                    nc.isChecked = false
+                }
+                updateButtonState()
+            }
+        }
+
+        updateButtonState()
+
+        concluirButton.setOnClickListener {
+            val itens = JSONArray()
+            triplets.forEachIndexed { idx, (c, nc, na) ->
+                val obj = JSONObject()
+                obj.put("numero", 301 + idx)
+                obj.put("pergunta", perguntas[idx])
+                val resp = JSONArray()
+                resp.put(
+                    when {
+                        c.isChecked -> "C"
+                        nc.isChecked -> "NC"
+                        na.isChecked -> "NA"
+                        else -> ""
+                    }
+                )
+                obj.put("resposta", resp)
+                itens.put(obj)
+            }
+            val payload = JSONObject()
+            payload.put("obra", obra)
+            payload.put("ano", ano)
+            payload.put("montador", montador)
+            payload.put("itens", itens)
+            Thread { enviarChecklist(payload) }.start()
+            finish()
+        }
+    }
+
+    private fun enviarChecklist(json: JSONObject) {
+        val urls = listOf(
+            "http://10.0.2.2:5000/json_api/posto03_pre/upload",
+            "http://192.168.0.151:5000/json_api/posto03_pre/upload",
+            "http://192.168.0.135:5000/json_api/posto03_pre/upload",
+        )
+        for (addr in urls) {
+            try {
+                val url = URL(addr)
+                val conn = url.openConnection() as HttpURLConnection
+                conn.requestMethod = "POST"
+                conn.doOutput = true
+                conn.setRequestProperty("Content-Type", "application/json")
+                OutputStreamWriter(conn.outputStream).use { it.write(json.toString()) }
+                val code = conn.responseCode
+                conn.disconnect()
+                if (code in 200..299) break
+            } catch (_: Exception) {
+                // tenta próximo endereço
+            }
+        }
+    }
+}

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto03PreInspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto03PreInspActivity.kt
@@ -1,0 +1,153 @@
+package com.example.appoficina
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.CheckBox
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
+
+class ChecklistPosto03PreInspActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_checklist_posto03_pre_montagem_01)
+
+        val obra = intent.getStringExtra("obra") ?: ""
+        val ano = intent.getStringExtra("ano") ?: ""
+        val inspetor = intent.getStringExtra("inspetor") ?: ""
+
+        val perguntas = listOf(
+            "3.1 - COMPONENTES: Montagem",
+            "3.1 - COMPONENTES: Montagem de acessórios",
+            "3.1 - COMPONENTES: Identificação",
+            "3.2 - RÉGUAS DE BORNES: Montagem",
+            "3.2 - RÉGUAS DE BORNES: Montagem de acessórios",
+            "3.2 - RÉGUAS DE BORNES: Identificação",
+            "3.3 - BARRAMENTO FRONTAL: Montagem",
+            "3.3 - BARRAMENTO FRONTAL: Parafusos/ Porcas/ Arruelas - Campo",
+            "3.3 - BARRAMENTO FRONTAL: Fabricação de anteparos em policarbonato",
+            "3.3 - BARRAMENTO FRONTAL: Colagem etiquetas dos anteparos",
+            "3.3 - BARRAMENTO FRONTAL: Identificação por projeto de anteparos",
+            "3.3 - BARRAMENTO FRONTAL: Separação de anteparos do barramento POSTO - 07",
+            "3.4 - PORTA: Nome do painel",
+            "3.4 - PORTA: Etiqueta de dados",
+            "3.4 - PORTA: Etiqueta de advertencia",
+            "3.4 - PORTA: Etiquetas externas dispositivos",
+            "3.4 - PORTA: Etiqueta de circuitos",
+            "3.4 - PORTA: Etiqueta de componentes",
+        )
+
+        val container = findViewById<LinearLayout>(R.id.questions_container)
+        val triplets = mutableListOf<Triple<CheckBox, CheckBox, CheckBox>>()
+
+        perguntas.forEach { pergunta ->
+            val tv = TextView(this)
+            tv.text = pergunta
+            container.addView(tv)
+            val row = LinearLayout(this)
+            row.orientation = LinearLayout.HORIZONTAL
+            val c = CheckBox(this)
+            c.text = "C"
+            val nc = CheckBox(this)
+            nc.text = "N.C"
+            nc.setPadding(24, 0, 0, 0)
+            val na = CheckBox(this)
+            na.text = "N.A"
+            na.setPadding(24, 0, 0, 0)
+            row.addView(c)
+            row.addView(nc)
+            row.addView(na)
+            container.addView(row)
+            triplets.add(Triple(c, nc, na))
+        }
+
+        val concluirButton = findViewById<Button>(R.id.btnConcluirPosto03Pre)
+
+        fun updateButtonState() {
+            concluirButton.isEnabled = triplets.all { (c, nc, na) ->
+                c.isChecked || nc.isChecked || na.isChecked
+            }
+        }
+
+        triplets.forEach { (c, nc, na) ->
+            c.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    nc.isChecked = false
+                    na.isChecked = false
+                }
+                updateButtonState()
+            }
+            nc.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    c.isChecked = false
+                    na.isChecked = false
+                }
+                updateButtonState()
+            }
+            na.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    c.isChecked = false
+                    nc.isChecked = false
+                }
+                updateButtonState()
+            }
+        }
+
+        updateButtonState()
+
+        concluirButton.setOnClickListener {
+            val itens = JSONArray()
+            triplets.forEachIndexed { idx, (c, nc, na) ->
+                val obj = JSONObject()
+                obj.put("numero", 301 + idx)
+                obj.put("pergunta", perguntas[idx])
+                val resp = JSONArray()
+                resp.put(
+                    when {
+                        c.isChecked -> "C"
+                        nc.isChecked -> "NC"
+                        na.isChecked -> "NA"
+                        else -> ""
+                    }
+                )
+                obj.put("resposta", resp)
+                itens.put(obj)
+            }
+            val payload = JSONObject()
+            payload.put("obra", obra)
+            payload.put("ano", ano)
+            payload.put("inspetor", inspetor)
+            payload.put("itens", itens)
+            Thread { enviarChecklist(payload) }.start()
+            finish()
+        }
+    }
+
+    private fun enviarChecklist(json: JSONObject) {
+        val urls = listOf(
+            "http://10.0.2.2:5000/json_api/posto03_pre/insp/upload",
+            "http://192.168.0.151:5000/json_api/posto03_pre/insp/upload",
+            "http://192.168.0.135:5000/json_api/posto03_pre/insp/upload",
+        )
+        for (addr in urls) {
+            try {
+                val url = URL(addr)
+                val conn = url.openConnection() as HttpURLConnection
+                conn.requestMethod = "POST"
+                conn.doOutput = true
+                conn.setRequestProperty("Content-Type", "application/json")
+                OutputStreamWriter(conn.outputStream).use { it.write(json.toString()) }
+                val code = conn.responseCode
+                conn.disconnect()
+                if (code in 200..299) break
+            } catch (_: Exception) {
+                // tenta próximo endereço
+            }
+        }
+    }
+}

--- a/AppOficina/app/src/main/java/com/example/appoficina/InspetorActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/InspetorActivity.kt
@@ -18,7 +18,7 @@ class InspetorActivity : AppCompatActivity() {
 
         val fragments: List<Fragment> = listOf(
             Posto02InspetorFragment(),
-            SimpleTextFragment.newInstance("03 - POSTO - 03 PRÉ-MONTAGEM - 01"),
+            Posto03PreMontagemInspetorFragment(),
             SimpleTextFragment.newInstance("04 - POSTO - 04 BARRAMENTO"),
             SimpleTextFragment.newInstance("05 - POSTO - 05 CABLAGEM - 01"),
             SimpleTextFragment.newInstance("06 - POSTO - 06 PRÉ-MONTAGEM - 02"),

--- a/AppOficina/app/src/main/java/com/example/appoficina/MainActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/MainActivity.kt
@@ -80,7 +80,7 @@ class MainActivity : AppCompatActivity() {
         val fragments: List<Fragment> = listOf(
             Posto01MateriaisFragment(),
             Posto02OficinaFragment(),
-            SimpleTextFragment.newInstance("03 - POSTO - 03 PRÉ-MONTAGEM - 01"),
+            Posto03PreMontagemFragment(),
             SimpleTextFragment.newInstance("04 - POSTO - 04 BARRAMENTO"),
             SimpleTextFragment.newInstance("05 - POSTO - 05 CABLAGEM - 01"),
             SimpleTextFragment.newInstance("06 - POSTO - 06 PRÉ-MONTAGEM - 02"),

--- a/AppOficina/app/src/main/java/com/example/appoficina/Posto03PreMontagemFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/Posto03PreMontagemFragment.kt
@@ -1,0 +1,126 @@
+package com.example.appoficina
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.Fragment
+import org.json.JSONArray
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+
+class Posto03PreMontagemFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_posto02_oficina, container, false)
+        val listContainer: LinearLayout = view.findViewById(R.id.projetos_container)
+
+        Thread {
+            val urls = listOf(
+                "http://10.0.2.2:5000/json_api/posto03_pre/projects",
+                "http://192.168.0.151:5000/json_api/posto03_pre/projects",
+                "http://192.168.0.135:5000/json_api/posto03_pre/projects",
+            )
+            var loaded = false
+            for (address in urls) {
+                try {
+                    val url = URL(address)
+                    val conn = url.openConnection() as HttpURLConnection
+                    val response = conn.inputStream.bufferedReader().use { it.readText() }
+                    conn.disconnect()
+
+                    val projetos = JSONObject(response).optJSONArray("projetos") ?: JSONArray()
+                    if (!isAdded) return@Thread
+                    activity?.runOnUiThread {
+                        listContainer.removeAllViews()
+                        for (i in 0 until projetos.length()) {
+                            val obj = projetos.getJSONObject(i)
+                            val obra = obj.optString("obra")
+                            val ano = obj.optString("ano")
+                            val tv = TextView(requireContext())
+                            tv.text = String.format("%02d - %s - %s", i + 1, obra, ano)
+                            tv.setPadding(0, 0, 0, 16)
+                            tv.setOnClickListener {
+                                Thread {
+                                    val urlsChecklist = listOf(
+                                        "http://10.0.2.2:5000/json_api/posto03_pre/checklist?obra=" +
+                                            URLEncoder.encode(obra, "UTF-8"),
+                                        "http://192.168.0.151:5000/json_api/posto03_pre/checklist?obra=" +
+                                            URLEncoder.encode(obra, "UTF-8"),
+                                        "http://192.168.0.135:5000/json_api/posto03_pre/checklist?obra=" +
+                                            URLEncoder.encode(obra, "UTF-8"),
+                                    )
+                                    var divergencias: JSONArray? = null
+                                    var found = false
+                                    for (addr in urlsChecklist) {
+                                        try {
+                                            val url = URL(addr)
+                                            val conn = url.openConnection() as HttpURLConnection
+                                            val response = conn.inputStream.bufferedReader().use { it.readText() }
+                                            conn.disconnect()
+                                            val json = JSONObject(response)
+                                            divergencias = json.optJSONObject("posto03_pre_montagem_01")?.optJSONArray("divergencias")
+                                            found = true
+                                            break
+                                        } catch (_: Exception) {
+                                        }
+                                    }
+                                    if (!isAdded) return@Thread
+                                    activity?.runOnUiThread {
+                                        if (found && divergencias != null && divergencias!!.length() > 0) {
+                                            val intent = Intent(requireContext(), PreviewDivergenciasActivity::class.java)
+                                            intent.putExtra("obra", obra)
+                                            intent.putExtra("ano", ano)
+                                            intent.putExtra("divergencias", divergencias.toString())
+                                            startActivity(intent)
+                                        } else {
+                                            val input = EditText(requireContext())
+                                            AlertDialog.Builder(requireContext())
+                                                .setTitle("Nome do montador")
+                                                .setView(input)
+                                                .setPositiveButton("OK") { _, _ ->
+                                                    val nome = input.text.toString()
+                                                    val intent = Intent(requireContext(), ChecklistPosto03PreActivity::class.java)
+                                                    intent.putExtra("obra", obra)
+                                                    intent.putExtra("ano", ano)
+                                                    intent.putExtra("montador", nome)
+                                                    startActivity(intent)
+                                                }
+                                                .setNegativeButton("Cancelar", null)
+                                                .show()
+                                        }
+                                    }
+                                }.start()
+                            }
+                            listContainer.addView(tv)
+                        }
+                    }
+                    loaded = true
+                    break
+                } catch (_: Exception) {
+                    // tenta proximo endereço
+                }
+            }
+            if (!loaded && isAdded) {
+                activity?.runOnUiThread {
+                    listContainer.removeAllViews()
+                    val tv = TextView(requireContext())
+                    tv.text = "Não foi possível carregar os projetos"
+                    listContainer.addView(tv)
+                }
+            }
+        }.start()
+
+        return view
+    }
+}

--- a/AppOficina/app/src/main/java/com/example/appoficina/Posto03PreMontagemInspetorFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/Posto03PreMontagemInspetorFragment.kt
@@ -1,0 +1,89 @@
+package com.example.appoficina
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.Fragment
+import org.json.JSONArray
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+
+class Posto03PreMontagemInspetorFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_posto02_oficina, container, false)
+        val listContainer: LinearLayout = view.findViewById(R.id.projetos_container)
+
+        Thread {
+            val urls = listOf(
+                "http://10.0.2.2:5000/json_api/posto03_pre/insp/projects",
+                "http://192.168.0.151:5000/json_api/posto03_pre/insp/projects",
+                "http://192.168.0.135:5000/json_api/posto03_pre/insp/projects",
+            )
+            var loaded = false
+            for (address in urls) {
+                try {
+                    val url = URL(address)
+                    val conn = url.openConnection() as HttpURLConnection
+                    val response = conn.inputStream.bufferedReader().use { it.readText() }
+                    conn.disconnect()
+
+                    val projetos = JSONObject(response).optJSONArray("projetos") ?: JSONArray()
+                    if (!isAdded) return@Thread
+                    activity?.runOnUiThread {
+                        listContainer.removeAllViews()
+                        for (i in 0 until projetos.length()) {
+                            val obj = projetos.getJSONObject(i)
+                            val obra = obj.optString("obra")
+                            val ano = obj.optString("ano")
+                            val tv = TextView(requireContext())
+                            tv.text = String.format("%02d - %s - %s", i + 1, obra, ano)
+                            tv.setPadding(0, 0, 0, 16)
+                            tv.setOnClickListener {
+                                val input = EditText(requireContext())
+                                AlertDialog.Builder(requireContext())
+                                    .setTitle("Nome do inspetor")
+                                    .setView(input)
+                                    .setPositiveButton("OK") { _, _ ->
+                                        val nome = input.text.toString()
+                                        val intent = Intent(requireContext(), ChecklistPosto03PreInspActivity::class.java)
+                                        intent.putExtra("obra", obra)
+                                        intent.putExtra("ano", ano)
+                                        intent.putExtra("inspetor", nome)
+                                        startActivity(intent)
+                                    }
+                                    .setNegativeButton("Cancelar", null)
+                                    .show()
+                            }
+                            listContainer.addView(tv)
+                        }
+                    }
+                    loaded = true
+                    break
+                } catch (_: Exception) {
+                    // tenta proximo endereço
+                }
+            }
+            if (!loaded && isAdded) {
+                activity?.runOnUiThread {
+                    listContainer.removeAllViews()
+                    val tv = TextView(requireContext())
+                    tv.text = "Não foi possível carregar os projetos"
+                    listContainer.addView(tv)
+                }
+            }
+        }.start()
+
+        return view
+    }
+}

--- a/AppOficina/app/src/main/res/layout/activity_checklist_posto03_pre_montagem_01.xml
+++ b/AppOficina/app/src/main/res/layout/activity_checklist_posto03_pre_montagem_01.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp">
+
+        <LinearLayout
+            android:id="@+id/questions_container"
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <Button
+            android:id="@+id/btnConcluirPosto03Pre"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="Concluir" />
+    </LinearLayout>
+</ScrollView>

--- a/site/json_api/__init__.py
+++ b/site/json_api/__init__.py
@@ -210,6 +210,178 @@ def posto02_insp_upload():
     return jsonify({'caminho': dest_path, 'divergencias': divergencias})
 
 
+@bp.route('/posto03_pre/projects', methods=['GET'])
+def listar_posto03_pre_projetos():
+    """List projects awaiting pre-montagem 01 production."""
+    dir_path = os.path.join(BASE_DIR, 'Posto03_Pre_montagem_01')
+    if not os.path.isdir(dir_path):
+        return jsonify({'projetos': []})
+    arquivos = [f for f in os.listdir(dir_path) if f.endswith('.json')]
+    projetos = []
+    for nome in sorted(arquivos):
+        caminho = path.join(dir_path, nome)
+        try:
+            with open(caminho, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            projetos.append({
+                'arquivo': nome,
+                'obra': data.get('obra', path.splitext(nome)[0]),
+                'ano': data.get('ano', ''),
+            })
+        except Exception:
+            continue
+    return jsonify({'projetos': projetos})
+
+
+@bp.route('/posto03_pre/checklist', methods=['GET'])
+def obter_posto03_pre_checklist():
+    """Return full checklist data for a given obra in Pre-montagem 01."""
+    obra = request.args.get('obra')
+    if not obra:
+        return jsonify({'erro': 'obra obrigatória'}), 400
+
+    file_path = os.path.join(BASE_DIR, 'Posto03_Pre_montagem_01', f'checklist_{obra}.json')
+    if not os.path.exists(file_path):
+        return jsonify({'erro': 'arquivo não encontrado'}), 404
+
+    with open(file_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    return jsonify(data)
+
+
+@bp.route('/posto03_pre/upload', methods=['POST'])
+def posto03_pre_upload():
+    """Append Pre-montagem 01 checklist and move it for inspection."""
+    data = request.get_json() or {}
+    obra = data.get('obra')
+    if not obra:
+        return jsonify({'erro': 'obra obrigatória'}), 400
+
+    src_path = os.path.join(BASE_DIR, 'Posto03_Pre_montagem_01', f'checklist_{obra}.json')
+    if not os.path.exists(src_path):
+        return jsonify({'erro': 'arquivo não encontrado'}), 404
+
+    with open(src_path, 'r', encoding='utf-8') as f:
+        base = json.load(f)
+
+    itens: list = []
+    for item in data.get('itens', []):
+        numero = item.get('numero')
+        pergunta = item.get('pergunta')
+        resposta = item.get('resposta') if isinstance(item.get('resposta'), list) else None
+        itens.append({
+            'numero': numero,
+            'pergunta': pergunta,
+            'respostas': {'montador': resposta},
+        })
+
+    base['posto03_pre_montagem_01'] = {
+        'montador': data.get('montador'),
+        'itens': itens,
+    }
+
+    insp_dir = os.path.join(
+        BASE_DIR, 'Posto03_Pre_montagem_01', 'Posto03_Pre_montagem_01_Inspetor'
+    )
+    os.makedirs(insp_dir, exist_ok=True)
+    dest_path = os.path.join(insp_dir, f'checklist_{obra}.json')
+    with open(dest_path, 'w', encoding='utf-8') as f:
+        json.dump(base, f, ensure_ascii=False, indent=2)
+    try:
+        os.remove(src_path)
+    except OSError:
+        pass
+    return jsonify({'caminho': dest_path})
+
+
+@bp.route('/posto03_pre/insp/projects', methods=['GET'])
+def listar_posto03_pre_insp_proj():
+    """List projects awaiting Pre-montagem 01 inspection."""
+    dir_path = os.path.join(
+        BASE_DIR, 'Posto03_Pre_montagem_01', 'Posto03_Pre_montagem_01_Inspetor'
+    )
+    if not os.path.isdir(dir_path):
+        return jsonify({'projetos': []})
+    arquivos = [f for f in os.listdir(dir_path) if f.endswith('.json')]
+    projetos = []
+    for nome in sorted(arquivos):
+        caminho = path.join(dir_path, nome)
+        try:
+            with open(caminho, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            projetos.append({
+                'arquivo': nome,
+                'obra': data.get('obra', path.splitext(nome)[0]),
+                'ano': data.get('ano', ''),
+            })
+        except Exception:
+            continue
+    return jsonify({'projetos': projetos})
+
+
+@bp.route('/posto03_pre/insp/upload', methods=['POST'])
+def posto03_pre_insp_upload():
+    """Process inspector answers and advance or return checklist."""
+    data = request.get_json() or {}
+    obra = data.get('obra')
+    if not obra:
+        return jsonify({'erro': 'obra obrigatória'}), 400
+
+    src_path = os.path.join(
+        BASE_DIR, 'Posto03_Pre_montagem_01', 'Posto03_Pre_montagem_01_Inspetor', f'checklist_{obra}.json'
+    )
+    if not os.path.exists(src_path):
+        return jsonify({'erro': 'arquivo não encontrado'}), 404
+
+    with open(src_path, 'r', encoding='utf-8') as f:
+        base = json.load(f)
+
+    prod_itens = {
+        item.get('numero'): item
+        for item in base.get('posto03_pre_montagem_01', {}).get('itens', [])
+    }
+    for item in data.get('itens', []):
+        numero = item.get('numero')
+        pergunta = item.get('pergunta')
+        resposta = item.get('resposta') if isinstance(item.get('resposta'), list) else None
+        entry = prod_itens.setdefault(
+            numero, {'numero': numero, 'pergunta': pergunta, 'respostas': {}}
+        )
+        entry['pergunta'] = entry.get('pergunta') or pergunta
+        entry.setdefault('respostas', {})['inspetor'] = resposta
+
+    divergencias = []
+    for entry in prod_itens.values():
+        resp_mont = entry.get('respostas', {}).get('montador')
+        resp_insp = entry.get('respostas', {}).get('inspetor')
+        if resp_mont is not None and resp_insp is not None and resp_mont != resp_insp:
+            divergencias.append({
+                'numero': entry.get('numero'),
+                'pergunta': entry.get('pergunta'),
+                'montador': resp_mont,
+                'inspetor': resp_insp,
+            })
+
+    base['posto03_pre_montagem_01']['inspetor'] = data.get('inspetor')
+    base['posto03_pre_montagem_01']['itens'] = list(prod_itens.values())
+    if divergencias:
+        base['posto03_pre_montagem_01']['divergencias'] = divergencias
+        dest_dir = os.path.join(BASE_DIR, 'Posto03_Pre_montagem_01')
+    else:
+        base['posto03_pre_montagem_01']['divergencias'] = []
+        dest_dir = os.path.join(BASE_DIR, 'Posto04_Barramento')
+    os.makedirs(dest_dir, exist_ok=True)
+    dest_path = os.path.join(dest_dir, f'checklist_{obra}.json')
+    with open(dest_path, 'w', encoding='utf-8') as f:
+        json.dump(base, f, ensure_ascii=False, indent=2)
+    try:
+        os.remove(src_path)
+    except OSError:
+        pass
+    return jsonify({'caminho': dest_path, 'divergencias': divergencias})
+
+
 @bp.route('/revisao', methods=['GET'])
 def listar_revisao():
     """Return checklists whose answers diverge between departments."""


### PR DESCRIPTION
## Summary
- Add backend endpoints to handle Posto03 Pre-montagem 01 checklist lifecycle
- Introduce Android fragments and activities for montador and inspector with 18-item checklist
- Integrate new workflow into main and inspector navigation

## Testing
- `python -m py_compile site/json_api/__init__.py`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689942d9a000832f8d28dcde5cd5934d