### PR TITLE
Fix Pre-montagem checklist resend routing

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto04BarramentoActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto04BarramentoActivity.kt
@@ -119,7 +119,7 @@ class ChecklistPosto04BarramentoActivity : AppCompatActivity() {
     private fun enviarChecklist(json: JSONObject) {
         val urls = listOf(
             "http://192.168.0.151:5000/json_api/posto04/upload",
-!!        )
+        )
         for (addr in urls) {
             try {
                 val url = URL(addr)

--- a/AppOficina/app/src/main/java/com/example/appoficina/Posto03PreMontagemFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/Posto03PreMontagemFragment.kt
@@ -28,7 +28,7 @@ class Posto03PreMontagemFragment : Fragment() {
         Thread {
             val urls = listOf(
                 "http://192.168.0.151:5000/json_api/posto03_pre/projects",
-           )
+            )
             var loaded = false
             for (address in urls) {
                 try {
@@ -50,10 +50,9 @@ class Posto03PreMontagemFragment : Fragment() {
                             tv.setPadding(0, 0, 0, 16)
                             tv.setOnClickListener {
                                 Thread {
-                                   val urlsChecklist = listOf(
-               !
+                                    val urlsChecklist = listOf(
                                         "http://192.168.0.151:5000/json_api/posto03_pre/checklist?obra=" +
-                          
+                                            URLEncoder.encode(obra, "UTF-8"),
                                     )
                                     var divergencias: JSONArray? = null
                                     var found = false

--- a/AppOficina/app/src/main/java/com/example/appoficina/PreviewDivergenciasActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/PreviewDivergenciasActivity.kt
@@ -18,7 +18,7 @@ class PreviewDivergenciasActivity : AppCompatActivity() {
         val obra = intent.getStringExtra("obra") ?: ""
         val ano = intent.getStringExtra("ano") ?: ""
         val divergenciasStr = intent.getStringExtra("divergencias") ?: "[]"
-        val tipo = intent.getStringExtra("tipo") ?: "posto02"
+        val tipo = intent.getStringExtra("tipo")?.trim()?.lowercase() ?: "posto02"
 
         val divergencias = try { JSONArray(divergenciasStr) } catch (_: Exception) { JSONArray() }
         val container = findViewById<LinearLayout>(R.id.divergencias_container)
@@ -48,6 +48,7 @@ class PreviewDivergenciasActivity : AppCompatActivity() {
                 .setPositiveButton("OK") { _, _ ->
                     val nome = input.text.toString()
                     val (clazz, extraName) = when (tipo) {
+                        "posto02" -> ChecklistPosto02Activity::class.java to "producao"
                         "posto03_pre" -> ChecklistPosto03PreActivity::class.java to "montador"
                         "posto04_barramento" -> ChecklistPosto04BarramentoActivity::class.java to "montador"
                         else -> ChecklistPosto02Activity::class.java to "producao"


### PR DESCRIPTION
## Summary
- normalize `tipo` extra and route checklists to correct activity
- fix malformed URL lists in Posto04 Barramento and Posto03 Pré-montagem fragments

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a17f9d778832fb915a8f403d26521