### PR TITLE
Fix Posto03 flow and update API endpoints

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto03PreActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto03PreActivity.kt
@@ -131,7 +131,6 @@ class ChecklistPosto03PreActivity : AppCompatActivity() {
     private fun enviarChecklist(json: JSONObject) {
         val urls = listOf(
             "http://10.0.2.2:5000/json_api/posto03_pre/upload",
-            "http://192.168.0.151:5000/json_api/posto03_pre/upload",
             "http://192.168.0.135:5000/json_api/posto03_pre/upload",
         )
         for (addr in urls) {

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto03PreInspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto03PreInspActivity.kt
@@ -130,7 +130,8 @@ class ChecklistPosto03PreInspActivity : AppCompatActivity() {
 
     private fun enviarChecklist(json: JSONObject) {
         val urls = listOf(
-            "http://192.168.0.151:5000/json_api/posto03_pre/insp/upload",
+            "http://10.0.2.2:5000/json_api/posto03_pre/insp/upload",
+            "http://192.168.0.135:5000/json_api/posto03_pre/insp/upload",
         )
         for (addr in urls) {
             try {

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto04BarramentoActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto04BarramentoActivity.kt
@@ -118,7 +118,8 @@ class ChecklistPosto04BarramentoActivity : AppCompatActivity() {
 
     private fun enviarChecklist(json: JSONObject) {
         val urls = listOf(
-            "http://192.168.0.151:5000/json_api/posto04/upload",
+            "http://10.0.2.2:5000/json_api/posto04/upload",
+            "http://192.168.0.135:5000/json_api/posto04/upload",
         )
         for (addr in urls) {
             try {

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto04BarramentoInspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto04BarramentoInspActivity.kt
@@ -118,7 +118,8 @@ class ChecklistPosto04BarramentoInspActivity : AppCompatActivity() {
 
     private fun enviarChecklist(json: JSONObject) {
         val urls = listOf(
-            "http://192.168.0.151:5000/json_api/posto04/insp/upload",
+            "http://10.0.2.2:5000/json_api/posto04/insp/upload",
+            "http://192.168.0.135:5000/json_api/posto04/insp/upload",
         )
         for (addr in urls) {
             try {

--- a/AppOficina/app/src/main/java/com/example/appoficina/Posto04BarramentoFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/Posto04BarramentoFragment.kt
@@ -28,7 +28,6 @@ class Posto04BarramentoFragment : Fragment() {
         Thread {
             val urls = listOf(
                 "http://10.0.2.2:5000/json_api/posto04/projects",
-                "http://192.168.0.151:5000/json_api/posto04/projects",
                 "http://192.168.0.135:5000/json_api/posto04/projects",
             )
             var loaded = false
@@ -53,10 +52,10 @@ class Posto04BarramentoFragment : Fragment() {
                             tv.setOnClickListener {
                                 Thread {
                                  val urlsChecklist = listOf(
-                              
-                                        "http://192.168.0.151:5000/json_api/posto04/checklist?obra=" +
+                                        "http://10.0.2.2:5000/json_api/posto04/checklist?obra=" +
                                             URLEncoder.encode(obra, "UTF-8"),
-                                  
+                                        "http://192.168.0.135:5000/json_api/posto04/checklist?obra=" +
+                                            URLEncoder.encode(obra, "UTF-8"),
                                     )
                                     var divergencias: JSONArray? = null
                                     var found = false

--- a/AppOficina/app/src/main/java/com/example/appoficina/Posto04BarramentoInspetorFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/Posto04BarramentoInspetorFragment.kt
@@ -27,7 +27,6 @@ class Posto04BarramentoInspetorFragment : Fragment() {
         Thread {
             val urls = listOf(
                 "http://10.0.2.2:5000/json_api/posto04/insp/projects",
-                "http://192.168.0.151:5000/json_api/posto04/insp/projects",
                 "http://192.168.0.135:5000/json_api/posto04/insp/projects",
             )
             var loaded = false

--- a/AppOficina/app/src/main/res/xml/network_security_config.xml
+++ b/AppOficina/app/src/main/res/xml/network_security_config.xml
@@ -3,6 +3,5 @@
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">10.0.2.2</domain>
         <domain includeSubdomains="true">192.168.0.135</domain>
-        <domain includeSubdomains="true">192.168.0.151</domain>
     </domain-config>
 </network-security-config>

--- a/site/json_api/__init__.py
+++ b/site/json_api/__init__.py
@@ -213,7 +213,7 @@ def posto02_insp_upload():
 @bp.route('/posto04/projects', methods=['GET'])
 def listar_posto04_projetos():
     """List projects awaiting Barramento production."""
-    dir_path = os.path.join(BASE_DIR, 'Posto04_Barramento')
+    dir_path = os.path.join(BASE_DIR, 'POSTO_04_BARRAMENTO')
     if not os.path.isdir(dir_path):
         return jsonify({'projetos': []})
     arquivos = [f for f in os.listdir(dir_path) if f.endswith('.json')]
@@ -240,7 +240,7 @@ def obter_posto04_checklist():
     if not obra:
         return jsonify({'erro': 'obra obrigatória'}), 400
 
-    file_path = os.path.join(BASE_DIR, 'Posto04_Barramento', f'checklist_{obra}.json')
+    file_path = os.path.join(BASE_DIR, 'POSTO_04_BARRAMENTO', f'checklist_{obra}.json')
     if not os.path.exists(file_path):
         return jsonify({'erro': 'arquivo não encontrado'}), 404
 
@@ -258,7 +258,7 @@ def posto04_upload():
     if not obra:
         return jsonify({'erro': 'obra obrigatória'}), 400
 
-    src_path = os.path.join(BASE_DIR, 'Posto04_Barramento', f'checklist_{obra}.json')
+    src_path = os.path.join(BASE_DIR, 'POSTO_04_BARRAMENTO', f'checklist_{obra}.json')
     if not os.path.exists(src_path):
         return jsonify({'erro': 'arquivo não encontrado'}), 404
 
@@ -281,7 +281,7 @@ def posto04_upload():
         'itens': itens,
     }
 
-    insp_dir = os.path.join(BASE_DIR, 'Posto04_Barramento', 'Posto04_Barramento_Inspetor')
+    insp_dir = os.path.join(BASE_DIR, 'POSTO_04_BARRAMENTO', 'POSTO_04_BARRAMENTO_Inspetor')
     os.makedirs(insp_dir, exist_ok=True)
     dest_path = os.path.join(insp_dir, f'checklist_{obra}.json')
     with open(dest_path, 'w', encoding='utf-8') as f:
@@ -296,7 +296,7 @@ def posto04_upload():
 @bp.route('/posto04/insp/projects', methods=['GET'])
 def listar_posto04_insp_proj():
     """List projects awaiting Barramento inspection."""
-    dir_path = os.path.join(BASE_DIR, 'Posto04_Barramento', 'Posto04_Barramento_Inspetor')
+    dir_path = os.path.join(BASE_DIR, 'POSTO_04_BARRAMENTO', 'POSTO_04_BARRAMENTO_Inspetor')
     if not os.path.isdir(dir_path):
         return jsonify({'projetos': []})
     arquivos = [f for f in os.listdir(dir_path) if f.endswith('.json')]
@@ -325,7 +325,7 @@ def posto04_insp_upload():
         return jsonify({'erro': 'obra obrigatória'}), 400
 
     src_path = os.path.join(
-        BASE_DIR, 'Posto04_Barramento', 'Posto04_Barramento_Inspetor', f'checklist_{obra}.json'
+        BASE_DIR, 'POSTO_04_BARRAMENTO', 'POSTO_04_BARRAMENTO_Inspetor', f'checklist_{obra}.json'
     )
     if not os.path.exists(src_path):
         return jsonify({'erro': 'arquivo não encontrado'}), 404
@@ -361,7 +361,7 @@ def posto04_insp_upload():
     base['posto04_barramento']['itens'] = list(prod_itens.values())
     if divergencias:
         base['posto04_barramento']['divergencias'] = divergencias
-        dest_dir = os.path.join(BASE_DIR, 'Posto04_Barramento')
+        dest_dir = os.path.join(BASE_DIR, 'POSTO_04_BARRAMENTO')
     else:
         base['posto04_barramento']['divergencias'] = []
         dest_dir = os.path.join(BASE_DIR, 'Posto06_Pre_montagem_02')
@@ -535,7 +535,7 @@ def posto03_pre_insp_upload():
         dest_dir = os.path.join(BASE_DIR, 'Posto03_Pre_montagem_01')
     else:
         base['posto03_pre_montagem_01']['divergencias'] = []
-        dest_dir = os.path.join(BASE_DIR, 'Posto04_Barramento')
+        dest_dir = os.path.join(BASE_DIR, 'POSTO_04_BARRAMENTO')
     os.makedirs(dest_dir, exist_ok=True)
     dest_path = os.path.join(dest_dir, f'checklist_{obra}.json')
     with open(dest_path, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
## Summary
- update Android client URLs to use 192.168.0.135
- move approved Posto03 checklists to `POSTO_04_BARRAMENTO`
- remove old IP from network security config

## Testing
- `python -m py_compile site/json_api/__init__.py`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a291628a8832fa0211b858bc9967d