### PR TITLE
Stop auto-opening next checklist

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02InspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02InspActivity.kt
@@ -1,7 +1,6 @@
 package com.example.appoficina
 
 import android.content.Context
-import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import android.widget.CheckBox
@@ -132,11 +131,6 @@ class ChecklistPosto02InspActivity : AppCompatActivity() {
 
         seguirButton.setOnClickListener {
             Thread { enviarChecklist(buildPayload()) }.start()
-            val intent = Intent(this, ChecklistPosto03PreInspActivity::class.java)
-            intent.putExtra("obra", obra)
-            intent.putExtra("ano", ano)
-            intent.putExtra("inspetor", inspetor)
-            startActivity(intent)
             finish()
         }
     }

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto03PreInspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto03PreInspActivity.kt
@@ -1,6 +1,5 @@
 package com.example.appoficina
 
-import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import android.widget.CheckBox
@@ -139,11 +138,6 @@ class ChecklistPosto03PreInspActivity : AppCompatActivity() {
 
         seguirButton.setOnClickListener {
             Thread { enviarChecklist(buildPayload()) }.start()
-            val intent = Intent(this, ChecklistPosto04BarramentoInspActivity::class.java)
-            intent.putExtra("obra", obra)
-            intent.putExtra("ano", ano)
-            intent.putExtra("inspetor", inspetor)
-            startActivity(intent)
             finish()
         }
     }

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto04BarramentoInspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto04BarramentoInspActivity.kt
@@ -1,6 +1,5 @@
 package com.example.appoficina
 
-import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import android.widget.CheckBox
@@ -127,11 +126,6 @@ class ChecklistPosto04BarramentoInspActivity : AppCompatActivity() {
 
         seguirButton.setOnClickListener {
             Thread { enviarChecklist(buildPayload()) }.start()
-            val intent = Intent(this, ChecklistPosto05CablagemInspActivity::class.java)
-            intent.putExtra("obra", obra)
-            intent.putExtra("ano", ano)
-            intent.putExtra("inspetor", inspetor)
-            startActivity(intent)
             finish()
         }
     }

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto05CablagemInspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto05CablagemInspActivity.kt
@@ -1,6 +1,5 @@
 package com.example.appoficina
 
-import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import android.widget.CheckBox
@@ -127,11 +126,6 @@ class ChecklistPosto05CablagemInspActivity : AppCompatActivity() {
 
         seguirButton.setOnClickListener {
             Thread { enviarChecklist(buildPayload()) }.start()
-            val intent = Intent(this, ChecklistPosto06PreInspActivity::class.java)
-            intent.putExtra("obra", obra)
-            intent.putExtra("ano", ano)
-            intent.putExtra("inspetor", inspetor)
-            startActivity(intent)
             finish()
         }
     }

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto06PreInspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto06PreInspActivity.kt
@@ -1,6 +1,5 @@
 package com.example.appoficina
 
-import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import android.widget.CheckBox
@@ -128,11 +127,6 @@ class ChecklistPosto06PreInspActivity : AppCompatActivity() {
 
         seguirButton.setOnClickListener {
             Thread { enviarChecklist(buildPayload()) }.start()
-            val intent = Intent(this, ChecklistPosto06Cablagem02InspActivity::class.java)
-            intent.putExtra("obra", obra)
-            intent.putExtra("ano", ano)
-            intent.putExtra("inspetor", inspetor)
-            startActivity(intent)
             finish()
         }
     }


### PR DESCRIPTION
## Summary
- Ensure "Seguir para proximo posto" buttons only send data and close the screen for inspectors
- Remove automatic navigation to subsequent checklists

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b7c311560832f8c3e0ffcd181ef6b