### PR TITLE
fix: advance to next station

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02InspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02InspActivity.kt
@@ -1,6 +1,7 @@
 package com.example.appoficina
 
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import android.widget.CheckBox
@@ -132,6 +133,11 @@ class ChecklistPosto02InspActivity : AppCompatActivity() {
         seguirButton.setOnClickListener {
             val payload = buildPayload()
             Thread { enviarProximoPosto(payload) }.start()
+            val intent = Intent(this, ChecklistPosto03PreInspActivity::class.java)
+            intent.putExtra("obra", obra)
+            intent.putExtra("ano", ano)
+            intent.putExtra("inspetor", inspetor)
+            startActivity(intent)
             finish()
         }
     }

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto03PreInspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto03PreInspActivity.kt
@@ -1,5 +1,6 @@
 package com.example.appoficina
 
+import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import android.widget.CheckBox
@@ -139,6 +140,11 @@ class ChecklistPosto03PreInspActivity : AppCompatActivity() {
         seguirButton.setOnClickListener {
             val payload = buildPayload()
             Thread { enviarProximoPosto(payload) }.start()
+            val intent = Intent(this, ChecklistPosto04BarramentoInspActivity::class.java)
+            intent.putExtra("obra", obra)
+            intent.putExtra("ano", ano)
+            intent.putExtra("inspetor", inspetor)
+            startActivity(intent)
             finish()
         }
     }

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto04BarramentoInspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto04BarramentoInspActivity.kt
@@ -1,5 +1,6 @@
 package com.example.appoficina
 
+import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import android.widget.CheckBox
@@ -127,6 +128,11 @@ class ChecklistPosto04BarramentoInspActivity : AppCompatActivity() {
         seguirButton.setOnClickListener {
             val payload = buildPayload()
             Thread { enviarProximoPosto(payload) }.start()
+            val intent = Intent(this, ChecklistPosto05CablagemInspActivity::class.java)
+            intent.putExtra("obra", obra)
+            intent.putExtra("ano", ano)
+            intent.putExtra("inspetor", inspetor)
+            startActivity(intent)
             finish()
         }
     }

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto05CablagemInspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto05CablagemInspActivity.kt
@@ -1,5 +1,6 @@
 package com.example.appoficina
 
+import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import android.widget.CheckBox
@@ -127,6 +128,11 @@ class ChecklistPosto05CablagemInspActivity : AppCompatActivity() {
         seguirButton.setOnClickListener {
             val payload = buildPayload()
             Thread { enviarProximoPosto(payload) }.start()
+            val intent = Intent(this, ChecklistPosto06PreInspActivity::class.java)
+            intent.putExtra("obra", obra)
+            intent.putExtra("ano", ano)
+            intent.putExtra("inspetor", inspetor)
+            startActivity(intent)
             finish()
         }
     }

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto06Cablagem02InspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto06Cablagem02InspActivity.kt
@@ -1,5 +1,6 @@
 package com.example.appoficina
 
+import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import android.widget.CheckBox
@@ -127,6 +128,12 @@ class ChecklistPosto06Cablagem02InspActivity : AppCompatActivity() {
         seguirButton.setOnClickListener {
             val payload = buildPayload()
             Thread { enviarProximoPosto(payload) }.start()
+            val intent = Intent(this, PreviewDivergenciasActivity::class.java)
+            intent.putExtra("obra", obra)
+            intent.putExtra("ano", ano)
+            intent.putExtra("divergencias", "[]")
+            intent.putExtra("tipo", "posto06_cablagem")
+            startActivity(intent)
             finish()
         }
     }

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto06PreInspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto06PreInspActivity.kt
@@ -1,5 +1,6 @@
 package com.example.appoficina
 
+import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import android.widget.CheckBox
@@ -128,6 +129,11 @@ class ChecklistPosto06PreInspActivity : AppCompatActivity() {
         seguirButton.setOnClickListener {
             val payload = buildPayload()
             Thread { enviarProximoPosto(payload) }.start()
+            val intent = Intent(this, ChecklistPosto06Cablagem02InspActivity::class.java)
+            intent.putExtra("obra", obra)
+            intent.putExtra("ano", ano)
+            intent.putExtra("inspetor", inspetor)
+            startActivity(intent)
             finish()
         }
     }


### PR DESCRIPTION
## Summary
- navigate to next checklist activity when "Seguir" is tapped in inspector screens
- show final divergences screen after cablagem step

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b8f57d340832faa334ad7b432aa10