### PR TITLE
Route inspector follow-ups to next station

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02InspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02InspActivity.kt
@@ -1,10 +1,10 @@
 package com.example.appoficina
 
 import android.content.Context
-import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import android.widget.CheckBox
+import android.widget.Toast
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import org.json.JSONArray
@@ -131,13 +131,11 @@ class ChecklistPosto02InspActivity : AppCompatActivity() {
         }
 
         seguirButton.setOnClickListener {
-            Thread { enviarChecklist(buildPayload()) }.start()
-            val intent = Intent(this, ChecklistPosto03PreInspActivity::class.java)
-            intent.putExtra("obra", obra)
-            intent.putExtra("ano", ano)
-            intent.putExtra("inspetor", inspetor)
-            startActivity(intent)
-            finish()
+            val payload = buildPayload()
+            seguirButton.isEnabled = false
+            concluirButton.isEnabled = false
+            Thread { enviarProximoPosto(payload) }.start()
+            Toast.makeText(this, "Encaminhado ao próximo posto", Toast.LENGTH_SHORT).show()
         }
     }
 
@@ -161,6 +159,23 @@ class ChecklistPosto02InspActivity : AppCompatActivity() {
             } catch (_: Exception) {
                 // tenta próximo endereço
             }
+        }
+    }
+
+    private fun enviarProximoPosto(json: JSONObject) {
+        val ip = getSharedPreferences("config", Context.MODE_PRIVATE)
+            .getString("api_ip", "192.168.0.135")
+        val address = "http://$ip:5000/json_api/posto03_pre/upload"
+        try {
+            val url = URL(address)
+            val conn = url.openConnection() as HttpURLConnection
+            conn.requestMethod = "POST"
+            conn.doOutput = true
+            conn.setRequestProperty("Content-Type", "application/json")
+            OutputStreamWriter(conn.outputStream).use { it.write(json.toString()) }
+            conn.responseCode
+            conn.disconnect()
+        } catch (_: Exception) {
         }
     }
 }

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto03PreInspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto03PreInspActivity.kt
@@ -1,11 +1,11 @@
 package com.example.appoficina
 
-import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import android.widget.CheckBox
 import android.widget.LinearLayout
 import android.widget.TextView
+import android.widget.Toast
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import org.json.JSONArray
@@ -138,13 +138,11 @@ class ChecklistPosto03PreInspActivity : AppCompatActivity() {
         }
 
         seguirButton.setOnClickListener {
-            Thread { enviarChecklist(buildPayload()) }.start()
-            val intent = Intent(this, ChecklistPosto04BarramentoInspActivity::class.java)
-            intent.putExtra("obra", obra)
-            intent.putExtra("ano", ano)
-            intent.putExtra("inspetor", inspetor)
-            startActivity(intent)
-            finish()
+            val payload = buildPayload()
+            seguirButton.isEnabled = false
+            concluirButton.isEnabled = false
+            Thread { enviarProximoPosto(payload) }.start()
+            Toast.makeText(this, "Encaminhado ao próximo posto", Toast.LENGTH_SHORT).show()
         }
     }
 
@@ -152,6 +150,23 @@ class ChecklistPosto03PreInspActivity : AppCompatActivity() {
         val ip = getSharedPreferences("config", MODE_PRIVATE)
             .getString("api_ip", "192.168.0.135")
         val address = "http://$ip:5000/json_api/posto03_pre/insp/upload"
+        try {
+            val url = URL(address)
+            val conn = url.openConnection() as HttpURLConnection
+            conn.requestMethod = "POST"
+            conn.doOutput = true
+            conn.setRequestProperty("Content-Type", "application/json")
+            OutputStreamWriter(conn.outputStream).use { it.write(json.toString()) }
+            conn.responseCode
+            conn.disconnect()
+        } catch (_: Exception) {
+        }
+    }
+
+    private fun enviarProximoPosto(json: JSONObject) {
+        val ip = getSharedPreferences("config", MODE_PRIVATE)
+            .getString("api_ip", "192.168.0.135")
+        val address = "http://$ip:5000/json_api/posto04/upload"
         try {
             val url = URL(address)
             val conn = url.openConnection() as HttpURLConnection

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto04BarramentoInspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto04BarramentoInspActivity.kt
@@ -1,11 +1,11 @@
 package com.example.appoficina
 
-import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import android.widget.CheckBox
 import android.widget.LinearLayout
 import android.widget.TextView
+import android.widget.Toast
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import org.json.JSONArray
@@ -126,13 +126,11 @@ class ChecklistPosto04BarramentoInspActivity : AppCompatActivity() {
         }
 
         seguirButton.setOnClickListener {
-            Thread { enviarChecklist(buildPayload()) }.start()
-            val intent = Intent(this, ChecklistPosto05CablagemInspActivity::class.java)
-            intent.putExtra("obra", obra)
-            intent.putExtra("ano", ano)
-            intent.putExtra("inspetor", inspetor)
-            startActivity(intent)
-            finish()
+            val payload = buildPayload()
+            seguirButton.isEnabled = false
+            concluirButton.isEnabled = false
+            Thread { enviarProximoPosto(payload) }.start()
+            Toast.makeText(this, "Encaminhado ao próximo posto", Toast.LENGTH_SHORT).show()
         }
     }
 
@@ -140,6 +138,23 @@ class ChecklistPosto04BarramentoInspActivity : AppCompatActivity() {
         val ip = getSharedPreferences("config", MODE_PRIVATE)
             .getString("api_ip", "192.168.0.135")
         val address = "http://$ip:5000/json_api/posto04/insp/upload"
+        try {
+            val url = URL(address)
+            val conn = url.openConnection() as HttpURLConnection
+            conn.requestMethod = "POST"
+            conn.doOutput = true
+            conn.setRequestProperty("Content-Type", "application/json")
+            OutputStreamWriter(conn.outputStream).use { it.write(json.toString()) }
+            conn.responseCode
+            conn.disconnect()
+        } catch (_: Exception) {
+        }
+    }
+
+    private fun enviarProximoPosto(json: JSONObject) {
+        val ip = getSharedPreferences("config", MODE_PRIVATE)
+            .getString("api_ip", "192.168.0.135")
+        val address = "http://$ip:5000/json_api/posto05/upload"
         try {
             val url = URL(address)
             val conn = url.openConnection() as HttpURLConnection

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto05CablagemInspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto05CablagemInspActivity.kt
@@ -1,11 +1,11 @@
 package com.example.appoficina
 
-import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import android.widget.CheckBox
 import android.widget.LinearLayout
 import android.widget.TextView
+import android.widget.Toast
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import org.json.JSONArray
@@ -126,13 +126,11 @@ class ChecklistPosto05CablagemInspActivity : AppCompatActivity() {
         }
 
         seguirButton.setOnClickListener {
-            Thread { enviarChecklist(buildPayload()) }.start()
-            val intent = Intent(this, ChecklistPosto06PreInspActivity::class.java)
-            intent.putExtra("obra", obra)
-            intent.putExtra("ano", ano)
-            intent.putExtra("inspetor", inspetor)
-            startActivity(intent)
-            finish()
+            val payload = buildPayload()
+            seguirButton.isEnabled = false
+            concluirButton.isEnabled = false
+            Thread { enviarProximoPosto(payload) }.start()
+            Toast.makeText(this, "Encaminhado ao próximo posto", Toast.LENGTH_SHORT).show()
         }
     }
 
@@ -140,6 +138,23 @@ class ChecklistPosto05CablagemInspActivity : AppCompatActivity() {
         val ip = getSharedPreferences("config", MODE_PRIVATE)
             .getString("api_ip", "192.168.0.135")
         val address = "http://$ip:5000/json_api/posto05/insp/upload"
+        try {
+            val url = URL(address)
+            val conn = url.openConnection() as HttpURLConnection
+            conn.requestMethod = "POST"
+            conn.doOutput = true
+            conn.setRequestProperty("Content-Type", "application/json")
+            OutputStreamWriter(conn.outputStream).use { it.write(json.toString()) }
+            conn.responseCode
+            conn.disconnect()
+        } catch (_: Exception) {
+        }
+    }
+
+    private fun enviarProximoPosto(json: JSONObject) {
+        val ip = getSharedPreferences("config", MODE_PRIVATE)
+            .getString("api_ip", "192.168.0.135")
+        val address = "http://$ip:5000/json_api/posto06_pre/upload"
         try {
             val url = URL(address)
             val conn = url.openConnection() as HttpURLConnection

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto06Cablagem02InspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto06Cablagem02InspActivity.kt
@@ -5,6 +5,7 @@ import android.widget.Button
 import android.widget.CheckBox
 import android.widget.LinearLayout
 import android.widget.TextView
+import android.widget.Toast
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import org.json.JSONArray
@@ -125,8 +126,11 @@ class ChecklistPosto06Cablagem02InspActivity : AppCompatActivity() {
         }
 
         seguirButton.setOnClickListener {
-            Thread { enviarChecklist(buildPayload()) }.start()
-            finish()
+            val payload = buildPayload()
+            seguirButton.isEnabled = false
+            concluirButton.isEnabled = false
+            Thread { enviarProximoPosto(payload) }.start()
+            Toast.makeText(this, "Encaminhado ao próximo posto", Toast.LENGTH_SHORT).show()
         }
     }
 
@@ -134,6 +138,23 @@ class ChecklistPosto06Cablagem02InspActivity : AppCompatActivity() {
         val ip = getSharedPreferences("config", MODE_PRIVATE)
             .getString("api_ip", "192.168.0.135")
         val address = "http://$ip:5000/json_api/posto06_cab2/insp/upload"
+        try {
+            val url = URL(address)
+            val conn = url.openConnection() as HttpURLConnection
+            conn.requestMethod = "POST"
+            conn.doOutput = true
+            conn.setRequestProperty("Content-Type", "application/json")
+            OutputStreamWriter(conn.outputStream).use { it.write(json.toString()) }
+            conn.responseCode
+            conn.disconnect()
+        } catch (_: Exception) {
+        }
+    }
+
+    private fun enviarProximoPosto(json: JSONObject) {
+        val ip = getSharedPreferences("config", MODE_PRIVATE)
+            .getString("api_ip", "192.168.0.135")
+        val address = "http://$ip:5000/json_api/posto08_iqm/upload"
         try {
             val url = URL(address)
             val conn = url.openConnection() as HttpURLConnection

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto06PreInspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto06PreInspActivity.kt
@@ -1,11 +1,11 @@
 package com.example.appoficina
 
-import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import android.widget.CheckBox
 import android.widget.LinearLayout
 import android.widget.TextView
+import android.widget.Toast
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import org.json.JSONArray
@@ -127,13 +127,11 @@ class ChecklistPosto06PreInspActivity : AppCompatActivity() {
         }
 
         seguirButton.setOnClickListener {
-            Thread { enviarChecklist(buildPayload()) }.start()
-            val intent = Intent(this, ChecklistPosto06Cablagem02InspActivity::class.java)
-            intent.putExtra("obra", obra)
-            intent.putExtra("ano", ano)
-            intent.putExtra("inspetor", inspetor)
-            startActivity(intent)
-            finish()
+            val payload = buildPayload()
+            seguirButton.isEnabled = false
+            concluirButton.isEnabled = false
+            Thread { enviarProximoPosto(payload) }.start()
+            Toast.makeText(this, "Encaminhado ao próximo posto", Toast.LENGTH_SHORT).show()
         }
     }
 
@@ -141,6 +139,23 @@ class ChecklistPosto06PreInspActivity : AppCompatActivity() {
         val ip = getSharedPreferences("config", MODE_PRIVATE)
             .getString("api_ip", "192.168.0.135")
         val address = "http://$ip:5000/json_api/posto06_pre/insp/upload"
+        try {
+            val url = URL(address)
+            val conn = url.openConnection() as HttpURLConnection
+            conn.requestMethod = "POST"
+            conn.doOutput = true
+            conn.setRequestProperty("Content-Type", "application/json")
+            OutputStreamWriter(conn.outputStream).use { it.write(json.toString()) }
+            conn.responseCode
+            conn.disconnect()
+        } catch (_: Exception) {
+        }
+    }
+
+    private fun enviarProximoPosto(json: JSONObject) {
+        val ip = getSharedPreferences("config", MODE_PRIVATE)
+            .getString("api_ip", "192.168.0.135")
+        val address = "http://$ip:5000/json_api/posto06_cab2/upload"
         try {
             val url = URL(address)
             val conn = url.openConnection() as HttpURLConnection


### PR DESCRIPTION
## Summary
- Keep inspectors on their current checklist while the "Seguir para próximo posto" button forwards data to the next workstation
- Show a confirmation toast and disable further input to avoid duplicate forwarding

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b7c311560832f8c3e0ffcd181ef6b