### PR TITLE
Add IQM NC correction and IQE checklist

### DIFF
--- a/AppOficina/app/src/main/AndroidManifest.xml
+++ b/AppOficina/app/src/main/AndroidManifest.xml
@@ -39,6 +39,7 @@
         <activity android:name=".PreviewDivergenciasActivity" android:exported="false" />
         <activity android:name=".AdminConfigActivity" android:exported="false" />
         <activity android:name=".InspetorActivity" android:exported="false" />
+        <activity android:name=".ChecklistPosto08IqeActivity" android:exported="false" />
     </application>
 
 </manifest>

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto08IqeActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto08IqeActivity.kt
@@ -1,0 +1,157 @@
+package com.example.appoficina
+
+import android.content.Context
+import android.os.Bundle
+import android.widget.Button
+import android.widget.CheckBox
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
+
+class ChecklistPosto08IqeActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_checklist_posto08_iqe)
+
+        val obra = intent.getStringExtra("obra") ?: ""
+        val ano = intent.getStringExtra("ano") ?: ""
+        val inspetor = intent.getStringExtra("inspetor") ?: ""
+
+        val perguntas = listOf(
+            "Torque parafusos dos componentes",
+            "Torque parafusos barra/Isolador",
+            "Torque parafusos barra/barra",
+            "Lacre parafusos dos componentes",
+            "Intertravamento mecânico",
+            "Montagem dos componentes conforme o projeto",
+            "Montagem de acessórios dos componentes",
+            "Montagem de bornes",
+            "Montagem de acessórios dos bornes",
+            "Montagem de barramentos",
+            "Montagem das portas",
+            "Montagem das etiquetas",
+            "Funcionamento mecânico dos componentes",
+            "Funcionamento mecânico partes móveis invólucro",
+        )
+
+        val container = findViewById<LinearLayout>(R.id.questions_container)
+        val triplets = mutableListOf<Triple<CheckBox, CheckBox, CheckBox>>()
+
+        perguntas.forEach { pergunta ->
+            val tv = TextView(this)
+            tv.text = pergunta
+            container.addView(tv)
+            val row = LinearLayout(this)
+            row.orientation = LinearLayout.HORIZONTAL
+            val c = CheckBox(this)
+            c.text = "C"
+            val nc = CheckBox(this)
+            nc.text = "N.C"
+            nc.setPadding(24, 0, 0, 0)
+            val na = CheckBox(this)
+            na.text = "N.A"
+            na.setPadding(24, 0, 0, 0)
+            row.addView(c)
+            row.addView(nc)
+            row.addView(na)
+            container.addView(row)
+            triplets.add(Triple(c, nc, na))
+        }
+
+        val concluirButton = findViewById<Button>(R.id.btnConcluirPosto08Iqe)
+
+        fun updateButtonState() {
+            concluirButton.isEnabled = triplets.all { (c, nc, na) ->
+                c.isChecked || nc.isChecked || na.isChecked
+            }
+        }
+
+        triplets.forEach { (c, nc, na) ->
+            c.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    nc.isChecked = false
+                    na.isChecked = false
+                }
+                updateButtonState()
+            }
+            nc.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    c.isChecked = false
+                    na.isChecked = false
+                }
+                updateButtonState()
+            }
+            na.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    c.isChecked = false
+                    nc.isChecked = false
+                }
+                updateButtonState()
+            }
+        }
+
+        updateButtonState()
+
+        concluirButton.setOnClickListener {
+            Thread {
+                val payload = buildPayload(perguntas, triplets, obra, ano, inspetor)
+                enviarChecklist(payload, "/json_api/posto08_iqe/upload")
+            }.start()
+            finish()
+        }
+    }
+
+    private fun buildPayload(
+        perguntas: List<String>,
+        triplets: List<Triple<CheckBox, CheckBox, CheckBox>>,
+        obra: String,
+        ano: String,
+        inspetor: String,
+    ): JSONObject {
+        val itens = JSONArray()
+        triplets.forEachIndexed { idx, (c, nc, na) ->
+            val obj = JSONObject()
+            obj.put("numero", 801 + idx)
+            obj.put("pergunta", perguntas[idx])
+            val resp = JSONArray()
+            resp.put(
+                when {
+                    c.isChecked -> "C"
+                    nc.isChecked -> "NC"
+                    na.isChecked -> "NA"
+                    else -> ""
+                }
+            )
+            obj.put("resposta", resp)
+            itens.put(obj)
+        }
+        val payload = JSONObject()
+        payload.put("obra", obra)
+        payload.put("ano", ano)
+        payload.put("inspetor", inspetor)
+        payload.put("itens", itens)
+        return payload
+    }
+
+    private fun enviarChecklist(json: JSONObject, path: String) {
+        val ip = getSharedPreferences("config", Context.MODE_PRIVATE)
+            .getString("api_ip", "192.168.0.135")
+        val address = "http://$ip:5000$path"
+        try {
+            val url = URL(address)
+            val conn = url.openConnection() as HttpURLConnection
+            conn.requestMethod = "POST"
+            conn.doOutput = true
+            conn.setRequestProperty("Content-Type", "application/json")
+            OutputStreamWriter(conn.outputStream).use { it.write(json.toString()) }
+            conn.responseCode
+            conn.disconnect()
+        } catch (_: Exception) {
+        }
+    }
+}

--- a/AppOficina/app/src/main/java/com/example/appoficina/InspetorActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/InspetorActivity.kt
@@ -27,7 +27,7 @@ class InspetorActivity : AppCompatActivity() {
             Posto05CablagemInspetorFragment(),
             Posto06PreMontagemInspetorFragment(),
             Posto06Cablagem02InspetorFragment(),
-            SimpleTextFragment.newInstance("07 - POSTO - 08 IQM"),
+            Posto08IqmInspetorFragment(),
             SimpleTextFragment.newInstance("08 - POSTO - 08 IQE"),
             SimpleTextFragment.newInstance("POSTO - 08 TESTE")
         )

--- a/AppOficina/app/src/main/java/com/example/appoficina/Posto08IqmInspetorFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/Posto08IqmInspetorFragment.kt
@@ -1,0 +1,123 @@
+package com.example.appoficina
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import org.json.JSONArray
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+
+class Posto08IqmInspetorFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_posto02_oficina, container, false)
+        val listContainer: LinearLayout = view.findViewById(R.id.projetos_container)
+
+        Thread {
+            val ip = requireContext().getSharedPreferences("config", Context.MODE_PRIVATE)
+                .getString("api_ip", "192.168.0.135")
+            val address = "http://$ip:5000/json_api/posto08_iqm/projects"
+            var loaded = false
+            try {
+                val url = URL(address)
+                val conn = url.openConnection() as HttpURLConnection
+                val response = conn.inputStream.bufferedReader().use { it.readText() }
+                conn.disconnect()
+
+                val projetos = JSONObject(response).optJSONArray("projetos") ?: JSONArray()
+                if (!isAdded) return@Thread
+                activity?.runOnUiThread {
+                    listContainer.removeAllViews()
+                    for (i in 0 until projetos.length()) {
+                        val obj = projetos.getJSONObject(i)
+                        val obra = obj.optString("obra")
+                        val ano = obj.optString("ano")
+                        val tv = TextView(requireContext())
+                        tv.text = String.format("%02d - %s - %s", i + 1, obra, ano)
+                        tv.setPadding(0, 0, 0, 16)
+                        tv.setOnClickListener {
+                            Thread {
+                                val addr = "http://$ip:5000/json_api/posto08_iqm/checklist?obra=" +
+                                    URLEncoder.encode(obra, "UTF-8")
+                                var itens: JSONArray? = null
+                                var found = false
+                                try {
+                                    val u = URL(addr)
+                                    val c = u.openConnection() as HttpURLConnection
+                                    val resp = c.inputStream.bufferedReader().use { it.readText() }
+                                    c.disconnect()
+                                    val json = JSONObject(resp)
+                                    val root = json.optJSONObject("posto08_iqm") ?: json
+                                    itens = root.optJSONArray("itens")
+                                    found = true
+                                } catch (_: Exception) {
+                                }
+                                if (!isAdded) return@Thread
+                                activity?.runOnUiThread {
+                                    if (found && itens != null) {
+                                        val divergencias = JSONArray()
+                                        for (j in 0 until itens!!.length()) {
+                                            val item = itens!!.getJSONObject(j)
+                                            val respostas = item.optJSONObject("respostas") ?: JSONObject()
+                                            val funcResps = JSONObject()
+                                            val funcoes = arrayOf("montador", "produção", "inspetor")
+                                            for (func in funcoes) {
+                                                val arr = respostas.optJSONArray(func) ?: JSONArray()
+                                                for (k in 0 until arr.length()) {
+                                                    val orig = arr.optString(k)
+                                                    val r = orig.replace(".", "").trim().uppercase()
+                                                    if (r == "NC" || r == "NA") {
+                                                        funcResps.put(func, orig)
+                                                        break
+                                                    }
+                                                }
+                                            }
+                                            if (funcResps.length() > 0) {
+                                                val prev = JSONObject()
+                                                prev.put("numero", item.optInt("numero"))
+                                                prev.put("pergunta", item.optString("pergunta"))
+                                                prev.put("posto", "Posto 08 IQM")
+                                                prev.put("respostas", funcResps)
+                                                divergencias.put(prev)
+                                            }
+                                        }
+                                        val intent = Intent(requireContext(), PreviewDivergenciasActivity::class.java)
+                                        intent.putExtra("obra", obra)
+                                        intent.putExtra("ano", ano)
+                                        intent.putExtra("divergencias", divergencias.toString())
+                                        intent.putExtra("tipo", "insp_posto08_iqm")
+                                        startActivity(intent)
+                                    }
+                                }
+                            }.start()
+                        }
+                        listContainer.addView(tv)
+                    }
+                }
+                loaded = true
+            } catch (_: Exception) {
+            }
+            if (!loaded && isAdded) {
+                activity?.runOnUiThread {
+                    listContainer.removeAllViews()
+                    val tv = TextView(requireContext())
+                    tv.text = "Não foi possível carregar os projetos"
+                    listContainer.addView(tv)
+                }
+            }
+        }.start()
+
+        return view
+    }
+}

--- a/AppOficina/app/src/main/java/com/example/appoficina/PreviewDivergenciasActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/PreviewDivergenciasActivity.kt
@@ -1,5 +1,6 @@
 package com.example.appoficina
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
@@ -9,6 +10,11 @@ import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import org.json.JSONArray
+import org.json.JSONObject
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
 
 class PreviewDivergenciasActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -22,18 +28,40 @@ class PreviewDivergenciasActivity : AppCompatActivity() {
 
         val divergencias = try { JSONArray(divergenciasStr) } catch (_: Exception) { JSONArray() }
         val container = findViewById<LinearLayout>(R.id.divergencias_container)
-        for (i in 0 until divergencias.length()) {
-            val obj = divergencias.getJSONObject(i)
-            val numero = obj.optInt("numero")
-            val pergunta = obj.optString("pergunta")
-            val prodArr = obj.optJSONArray("produção") ?: JSONArray()
-            val inspArr = obj.optJSONArray("inspetor") ?: JSONArray()
-            val prodText = (0 until prodArr.length()).joinToString(", ") { prodArr.optString(it) }
-            val inspText = (0 until inspArr.length()).joinToString(", ") { inspArr.optString(it) }
-            val tv = TextView(this)
-            tv.text = "$numero - $pergunta\nProdução: $prodText\nInspetor: $inspText"
-            tv.setPadding(0, 0, 0, 16)
-            container.addView(tv)
+        if (tipo == "insp_posto08_iqm") {
+            for (i in 0 until divergencias.length()) {
+                val obj = divergencias.getJSONObject(i)
+                val posto = obj.optString("posto")
+                val numero = obj.optInt("numero")
+                val pergunta = obj.optString("pergunta")
+                val respObj = obj.optJSONObject("respostas") ?: JSONObject()
+                val entries = mutableListOf<String>()
+                val keys = respObj.keys()
+                while (keys.hasNext()) {
+                    val func = keys.next()
+                    val resp = respObj.optString(func)
+                    entries.add("$func: $resp")
+                }
+                val funcsText = entries.joinToString(", ")
+                val tv = TextView(this)
+                tv.text = "$posto | $numero | $pergunta | $funcsText"
+                tv.setPadding(0, 0, 0, 16)
+                container.addView(tv)
+            }
+        } else {
+            for (i in 0 until divergencias.length()) {
+                val obj = divergencias.getJSONObject(i)
+                val numero = obj.optInt("numero")
+                val pergunta = obj.optString("pergunta")
+                val prodArr = obj.optJSONArray("produção") ?: JSONArray()
+                val inspArr = obj.optJSONArray("inspetor") ?: JSONArray()
+                val prodText = (0 until prodArr.length()).joinToString(", ") { prodArr.optString(it) }
+                val inspText = (0 until inspArr.length()).joinToString(", ") { inspArr.optString(it) }
+                val tv = TextView(this)
+                tv.text = "$numero - $pergunta\nProdução: $prodText\nInspetor: $inspText"
+                tv.setPadding(0, 0, 0, 16)
+                container.addView(tv)
+            }
         }
 
         val actionButton = findViewById<Button>(R.id.btnCorrigir)
@@ -65,7 +93,11 @@ class PreviewDivergenciasActivity : AppCompatActivity() {
                         "insp_posto05_cablagem" -> ChecklistPosto05CablagemInspActivity::class.java to "inspetor"
                         "insp_posto06_pre" -> ChecklistPosto06PreInspActivity::class.java to "inspetor"
                         "insp_posto06_cablagem" -> ChecklistPosto06Cablagem02InspActivity::class.java to "inspetor"
+                        "insp_posto08_iqm" -> ChecklistPosto08IqeActivity::class.java to "inspetor"
                         else -> ChecklistPosto02Activity::class.java to "producao"
+                    }
+                    if (tipo == "insp_posto08_iqm") {
+                        corrigirNcIqm(obra)
                     }
                     val intent = Intent(this, clazz)
                     intent.putExtra("obra", obra)
@@ -77,5 +109,57 @@ class PreviewDivergenciasActivity : AppCompatActivity() {
                 .setNegativeButton("Cancelar", null)
                 .show()
         }
+    }
+
+    private fun corrigirNcIqm(obra: String) {
+        Thread {
+            val ip = getSharedPreferences("config", Context.MODE_PRIVATE)
+                .getString("api_ip", "192.168.0.135")
+            val addr = "http://$ip:5000/json_api/posto08_iqm/checklist?obra=" +
+                URLEncoder.encode(obra, "UTF-8")
+            try {
+                val url = URL(addr)
+                val conn = url.openConnection() as HttpURLConnection
+                val resp = conn.inputStream.bufferedReader().use { it.readText() }
+                conn.disconnect()
+                val json = JSONObject(resp)
+                val root = json.optJSONObject("posto08_iqm") ?: json
+                val itens = root.optJSONArray("itens") ?: JSONArray()
+                val correcoes = JSONArray()
+                for (i in 0 until itens.length()) {
+                    val item = itens.getJSONObject(i)
+                    val respostas = item.optJSONObject("respostas") ?: JSONObject()
+                    val inspArr = respostas.optJSONArray("inspetor") ?: JSONArray()
+                    var corrigiu = false
+                    for (j in 0 until inspArr.length()) {
+                        val r = inspArr.optString(j)
+                        if (r.equals("NC", true) || r.equals("N.C", true)) {
+                            inspArr.put(j, "C")
+                            corrigiu = true
+                        }
+                    }
+                    if (corrigiu) {
+                        correcoes.put(item.optInt("numero"))
+                    }
+                    respostas.put("inspetor", inspArr)
+                    item.put("respostas", respostas)
+                }
+                root.put("itens", itens)
+                root.put("correcoes", correcoes)
+                val payload = JSONObject()
+                payload.put("obra", json.optString("obra", obra))
+                payload.put("ano", json.optString("ano"))
+                payload.put("posto08_iqm", root)
+                val upUrl = URL("http://$ip:5000/json_api/posto08_iqm/update")
+                val upConn = upUrl.openConnection() as HttpURLConnection
+                upConn.requestMethod = "POST"
+                upConn.doOutput = true
+                upConn.setRequestProperty("Content-Type", "application/json")
+                OutputStreamWriter(upConn.outputStream).use { it.write(payload.toString()) }
+                upConn.responseCode
+                upConn.disconnect()
+            } catch (_: Exception) {
+            }
+        }.start()
     }
 }

--- a/AppOficina/app/src/main/res/layout/activity_checklist_posto08_iqe.xml
+++ b/AppOficina/app/src/main/res/layout/activity_checklist_posto08_iqe.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp">
+
+        <LinearLayout
+            android:id="@+id/questions_container"
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <Button
+            android:id="@+id/btnConcluirPosto08Iqe"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="Concluir" />
+    </LinearLayout>
+</ScrollView>

--- a/site/json_api/__init__.py
+++ b/site/json_api/__init__.py
@@ -87,6 +87,36 @@ def obter_posto02_checklist():
 
     return jsonify(data)
 
+
+@bp.route('/posto08_iqm/update', methods=['POST'])
+def atualizar_posto08_iqm():
+    """Overwrite IQM checklist for an obra."""
+    data = request.get_json() or {}
+    obra = data.get('obra')
+    if not obra:
+        return jsonify({'erro': 'obra obrigatória'}), 400
+    dir_path = os.path.join(BASE_DIR, 'posto08_IQM')
+    os.makedirs(dir_path, exist_ok=True)
+    file_path = os.path.join(dir_path, f'checklist_{obra}.json')
+    with open(file_path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+    return jsonify({'caminho': file_path})
+
+
+@bp.route('/posto08_iqe/upload', methods=['POST'])
+def posto08_iqe_upload():
+    """Store IQE inspector checklist."""
+    data = request.get_json() or {}
+    obra = data.get('obra')
+    if not obra:
+        return jsonify({'erro': 'obra obrigatória'}), 400
+    dir_path = os.path.join(BASE_DIR, 'posto08_IQE')
+    os.makedirs(dir_path, exist_ok=True)
+    file_path = os.path.join(dir_path, f'checklist_{obra}.json')
+    with open(file_path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+    return jsonify({'caminho': file_path})
+
   
   
 @bp.route('/posto02/upload', methods=['POST'])
@@ -1118,6 +1148,46 @@ def reenviar_checklist():
         pass
 
     return jsonify({'caminho': out_path})
+
+
+@bp.route('/posto08_iqm/projects', methods=['GET'])
+def listar_posto08_iqm_projetos():
+    """List projects available for IQM inspection."""
+    dir_path = os.path.join(BASE_DIR, 'posto08_IQM')
+    if not os.path.isdir(dir_path):
+        return jsonify({'projetos': []})
+    arquivos = [f for f in os.listdir(dir_path) if f.endswith('.json')]
+    projetos = []
+    for nome in sorted(arquivos):
+        caminho = path.join(dir_path, nome)
+        try:
+            with open(caminho, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            projetos.append({
+                'arquivo': nome,
+                'obra': data.get('obra', path.splitext(nome)[0]),
+                'ano': data.get('ano', ''),
+            })
+        except Exception:
+            continue
+    return jsonify({'projetos': projetos})
+
+
+@bp.route('/posto08_iqm/checklist', methods=['GET'])
+def obter_posto08_iqm_checklist():
+    """Return full IQM checklist data for a given obra."""
+    obra = request.args.get('obra')
+    if not obra:
+        return jsonify({'erro': 'obra obrigatória'}), 400
+
+    file_path = os.path.join(BASE_DIR, 'posto08_IQM', f'checklist_{obra}.json')
+    if not os.path.exists(file_path):
+        return jsonify({'erro': 'arquivo não encontrado'}), 404
+
+    with open(file_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    return jsonify(data)
 
 # legacy alias
 bp.add_url_rule('/upload', view_func=salvar_checklist, methods=['POST'])

--- a/site/json_api/posto08_IQM/checklist_OBRA_DEMO.json
+++ b/site/json_api/posto08_IQM/checklist_OBRA_DEMO.json
@@ -1,0 +1,36 @@
+{
+  "obra": "OBRA_DEMO",
+  "ano": "2024",
+  "posto08_iqm": {
+    "inspetor": "",
+    "itens": [
+      {
+        "numero": 1,
+        "pergunta": "Item com NC do montador e produção",
+        "respostas": {
+          "montador": ["NC"],
+          "produção": ["NC"],
+          "inspetor": ["C"]
+        }
+      },
+      {
+        "numero": 2,
+        "pergunta": "Item com NC do inspetor",
+        "respostas": {
+          "montador": ["C"],
+          "produção": ["C"],
+          "inspetor": ["NC"]
+        }
+      },
+      {
+        "numero": 3,
+        "pergunta": "Item conforme",
+        "respostas": {
+          "montador": ["C"],
+          "produção": ["C"],
+          "inspetor": ["C"]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- convert NC answers to C when inspector begins IQM review and log corrections
- add mechanical quality inspection (IQE) checklist activity
- expose endpoints to update IQM files and upload IQE results
- list only NC or NA questions across roles in IQM inspector preview
- format IQM preview to show only functions marking NC/NA
- display each role's NC/NA response in the IQM preview list
- remove demo IQM checklist file from repository
- restore IQM demo checklist as base data for preview

## Testing
- `pytest`
- `cd AppOficina && ./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cdb82367c832f8bcaa2a37be50a32