### PR TITLE
Filter NC answers in Posto08 IQM inspector preview

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/Posto08IqmInspetorFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/Posto08IqmInspetorFragment.kt
@@ -77,7 +77,7 @@ class Posto08IqmInspetorFragment : Fragment() {
                                                 for (k in 0 until arr.length()) {
                                                     val orig = arr.optString(k)
                                                     val r = orig.replace(".", "").trim().uppercase()
-                                                    if (r == "NC" || r == "NA") {
+                                                    if (r == "NC") {
                                                         funcResps.put(func, orig)
                                                         break
                                                     }


### PR DESCRIPTION
## Summary
- Collect NC responses from montador, produção, and inspetor when previewing IQM checklists
- Restore the agora20 checklist to its original state without test data

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e1e2cd30c832fabf77da98f09d9bc