### PR TITLE
Generate NC preview for IQM checklists

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/Posto08IqmInspetorFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/Posto08IqmInspetorFragment.kt
@@ -77,7 +77,7 @@ class Posto08IqmInspetorFragment : Fragment() {
                                                 for (k in 0 until arr.length()) {
                                                     val orig = arr.optString(k)
                                                     val r = orig.replace(".", "").trim().uppercase()
-                                                    if (r == "NC" || r == "NA") {
+                                                    if (r == "NC") {
                                                         funcResps.put(func, orig)
                                                         break
                                                     }


### PR DESCRIPTION
## Summary
- compute NC-answer preview for any checklist saved under posto08_IQM
- inject `pre_visualizacao` list of NC questions into IQM files on save/list/retrieve

## Testing
- `python -m py_compile site/json_api/__init__.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e1e2cd30c832fabf77da98f09d9bc