### PR TITLE
Generate NC preview for IQM checklists

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/Posto08IqmInspetorFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/Posto08IqmInspetorFragment.kt
@@ -77,7 +77,7 @@ class Posto08IqmInspetorFragment : Fragment() {
                                                 for (k in 0 until arr.length()) {
                                                     val orig = arr.optString(k)
                                                     val r = orig.replace(".", "").trim().uppercase()
-                                                    if (r == "NC" || r == "NA") {
+                                                    if (r == "NC") {
                                                         funcResps.put(func, orig)
                                                         break
                                                     }

--- a/site/json_api/__init__.py
+++ b/site/json_api/__init__.py
@@ -9,6 +9,78 @@ bp = Blueprint('json_api', __name__)
 BASE_DIR = os.path.dirname(__file__)
 
 
+def _collect_nc_items(data):
+    """Return list of items with at least one "NC" answer."""
+    nc_itens = []
+
+    def walk(obj):
+        if isinstance(obj, dict):
+            itens = obj.get("itens")
+            if isinstance(itens, list):
+                for item in itens:
+                    respostas = item.get("respostas", {})
+                    nc_respostas = {
+                        papel: resp
+                        for papel, resp in respostas.items()
+                        if isinstance(resp, list) and "NC" in resp
+                    }
+                    if nc_respostas:
+                        nc_itens.append(
+                            {
+                                "numero": item.get("numero"),
+                                "pergunta": item.get("pergunta"),
+                                "respostas": nc_respostas,
+                            }
+                        )
+            for value in obj.values():
+                walk(value)
+        elif isinstance(obj, list):
+            for value in obj:
+                walk(value)
+
+    walk(data)
+    return nc_itens
+
+
+def _collect_double_nc(data):
+    """Return list of answer blocks where both roles answered 'NC'."""
+    resultados = []
+
+    def walk(obj):
+        if isinstance(obj, dict):
+            keys = set(obj.keys())
+            if keys in ({"montador", "inspetor"}, {"suprimento", "produção"}):
+                valores = []
+                for v in obj.values():
+                    if isinstance(v, list) and len(v) == 1:
+                        valores.append(v[0])
+                if len(valores) == 2 and all(v == "NC" for v in valores):
+                    resultados.append(obj)
+            for v in obj.values():
+                walk(v)
+        elif isinstance(obj, list):
+            for item in obj:
+                walk(item)
+
+    walk(data)
+    return resultados
+
+
+def _ensure_nc_preview(file_path: str) -> None:
+    """Append preview of NC answers to ``file_path`` in-place."""
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        return
+
+    data["pre_visualizacao"] = _collect_nc_items(data)
+    data["respostas_duplas_NC"] = _collect_double_nc(data)
+
+    with open(file_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
 @bp.route('/checklist', methods=['POST'])
 def salvar_checklist():
     """Save a checklist payload to a timestamped JSON file."""
@@ -100,6 +172,7 @@ def listar_posto08_iqm_projetos():
     for nome in sorted(arquivos):
         caminho = path.join(dir_path, nome)
         try:
+            _ensure_nc_preview(caminho)
             with open(caminho, 'r', encoding='utf-8') as f:
                 data = json.load(f)
             projetos.append(
@@ -125,6 +198,7 @@ def obter_posto08_iqm_checklist():
     if not os.path.exists(file_path):
         return jsonify({'erro': 'arquivo não encontrado'}), 404
 
+    _ensure_nc_preview(file_path)
     with open(file_path, 'r', encoding='utf-8') as f:
         data = json.load(f)
 
@@ -143,6 +217,7 @@ def atualizar_posto08_iqm():
     file_path = os.path.join(dir_path, f'checklist_{obra}.json')
     with open(file_path, 'w', encoding='utf-8') as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
+    _ensure_nc_preview(file_path)
     return jsonify({'caminho': file_path})
 
 


### PR DESCRIPTION
## Summary
- compute NC-answer preview for any checklist saved under posto08_IQM
- inject `pre_visualizacao` list of NC questions into IQM files on save/list/retrieve
- detect blocks where two roles answered `NC` and store them under `respostas_duplas_NC`

## Testing
- `python -m py_compile site/json_api/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e1e2cd30c832fabf77da98f09d9bc