### PR TITLE
Generate NC preview for IQM checklists

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/Posto08IqmInspetorFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/Posto08IqmInspetorFragment.kt
@@ -50,7 +50,7 @@ class Posto08IqmInspetorFragment : Fragment() {
                             Thread {
                                 val addr = "http://$ip:5000/json_api/posto08_iqm/checklist?obra=" +
                                     URLEncoder.encode(obra, "UTF-8")
-                                var itens: JSONArray? = null
+                                var preview: JSONArray? = null
                                 var found = false
                                 try {
                                     val u = URL(addr)
@@ -59,38 +59,18 @@ class Posto08IqmInspetorFragment : Fragment() {
                                     c.disconnect()
                                     val json = JSONObject(resp)
                                     val root = json.optJSONObject("posto08_iqm") ?: json
-                                    itens = root.optJSONArray("itens")
+                                    preview = root.optJSONArray("pre_visualizacao") ?: JSONArray()
                                     found = true
                                 } catch (_: Exception) {
                                 }
                                 if (!isAdded) return@Thread
                                 activity?.runOnUiThread {
-                                    if (found && itens != null) {
+                                    if (found && preview != null) {
                                         val divergencias = JSONArray()
-                                        for (j in 0 until itens!!.length()) {
-                                            val item = itens!!.getJSONObject(j)
-                                            val respostas = item.optJSONObject("respostas") ?: JSONObject()
-                                            val funcResps = JSONObject()
-                                            val funcoes = arrayOf("montador", "produção", "inspetor")
-                                            for (func in funcoes) {
-                                                val arr = respostas.optJSONArray(func) ?: JSONArray()
-                                                for (k in 0 until arr.length()) {
-                                                    val orig = arr.optString(k)
-                                                    val r = orig.replace(".", "").trim().uppercase()
-                                                    if (r == "NC" || r == "NA") {
-                                                        funcResps.put(func, orig)
-                                                        break
-                                                    }
-                                                }
-                                            }
-                                            if (funcResps.length() > 0) {
-                                                val prev = JSONObject()
-                                                prev.put("numero", item.optInt("numero"))
-                                                prev.put("pergunta", item.optString("pergunta"))
-                                                prev.put("posto", "Posto 08 IQM")
-                                                prev.put("respostas", funcResps)
-                                                divergencias.put(prev)
-                                            }
+                                        for (j in 0 until preview!!.length()) {
+                                            val item = preview!!.getJSONObject(j)
+                                            item.put("posto", "Posto 08 IQM")
+                                            divergencias.put(item)
                                         }
                                         val intent = Intent(requireContext(), PreviewDivergenciasActivity::class.java)
                                         intent.putExtra("obra", obra)

--- a/site/json_api/__init__.py
+++ b/site/json_api/__init__.py
@@ -9,6 +9,80 @@ bp = Blueprint('json_api', __name__)
 BASE_DIR = os.path.dirname(__file__)
 
 
+def _collect_nc_items(data):
+    """Return list of items with at least one "NC" answer."""
+    nc_itens = []
+
+    def walk(obj):
+        if isinstance(obj, dict):
+            itens = obj.get("itens")
+            if isinstance(itens, list):
+                for item in itens:
+                    respostas = item.get("respostas", {})
+                    nc_respostas = {}
+                    for papel, resp in respostas.items():
+                        if isinstance(resp, list):
+                            for r in resp:
+                                if r.replace(".", "").strip().upper() == "NC":
+                                    nc_respostas[papel] = r
+                                    break
+                    if nc_respostas:
+                        nc_itens.append(
+                            {
+                                "numero": item.get("numero"),
+                                "pergunta": item.get("pergunta"),
+                                "respostas": nc_respostas,
+                            }
+                        )
+            for value in obj.values():
+                walk(value)
+        elif isinstance(obj, list):
+            for value in obj:
+                walk(value)
+
+    walk(data)
+    return nc_itens
+
+
+def _collect_double_nc(data):
+    """Return list of answer blocks where both roles answered 'NC'."""
+    resultados = []
+
+    def walk(obj):
+        if isinstance(obj, dict):
+            keys = set(obj.keys())
+            if keys in ({"montador", "inspetor"}, {"suprimento", "produção"}):
+                valores = []
+                for v in obj.values():
+                    if isinstance(v, list) and len(v) == 1:
+                        valores.append(v[0])
+                if len(valores) == 2 and all(v == "NC" for v in valores):
+                    resultados.append(obj)
+            for v in obj.values():
+                walk(v)
+        elif isinstance(obj, list):
+            for item in obj:
+                walk(item)
+
+    walk(data)
+    return resultados
+
+
+def _ensure_nc_preview(file_path: str) -> None:
+    """Append preview of NC answers to ``file_path`` in-place."""
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        return
+
+    data["pre_visualizacao"] = _collect_nc_items(data)
+    data["respostas_duplas_NC"] = _collect_double_nc(data)
+
+    with open(file_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
 @bp.route('/checklist', methods=['POST'])
 def salvar_checklist():
     """Save a checklist payload to a timestamped JSON file."""
@@ -100,6 +174,7 @@ def listar_posto08_iqm_projetos():
     for nome in sorted(arquivos):
         caminho = path.join(dir_path, nome)
         try:
+            _ensure_nc_preview(caminho)
             with open(caminho, 'r', encoding='utf-8') as f:
                 data = json.load(f)
             projetos.append(
@@ -125,6 +200,7 @@ def obter_posto08_iqm_checklist():
     if not os.path.exists(file_path):
         return jsonify({'erro': 'arquivo não encontrado'}), 404
 
+    _ensure_nc_preview(file_path)
     with open(file_path, 'r', encoding='utf-8') as f:
         data = json.load(f)
 
@@ -143,6 +219,7 @@ def atualizar_posto08_iqm():
     file_path = os.path.join(dir_path, f'checklist_{obra}.json')
     with open(file_path, 'w', encoding='utf-8') as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
+    _ensure_nc_preview(file_path)
     return jsonify({'caminho': file_path})
 
 


### PR DESCRIPTION
## Summary
- collect NC answers as raw strings when building pre_visualizacao
- show server-provided pre_visualizacao in Posto08 IQM inspector preview

## Testing
- `python -m py_compile site/json_api/__init__.py`
- `pytest`
- `cd AppOficina && ./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e1e2cd30c832fabf77da98f09d9bc