### PR TITLE
feat: list checklists on app startup

### DIFF
--- a/site/app.py
+++ b/site/app.py
@@ -6,6 +6,7 @@ from projetista import bp as projetista_bp
 from compras import bp as compras_bp
 from auth import bp as auth_bp
 from json_api import bp as json_api_bp, merge_directory, move_matching_checklists
+from json_api.list_checklists import collect_checklists
 from checklist_blueprint import bp as checklist_bp
 from flask_login import LoginManager, login_user, current_user
 from flask import Flask, request
@@ -52,6 +53,12 @@ def create_app():
     base_json = os.path.join(os.path.dirname(__file__), 'json_api')
     merge_directory(base_json)
     move_matching_checklists(base_json)
+
+    # Lista automaticamente os arquivos de checklist disponíveis
+    for folder, items in collect_checklists().items():
+        print(f"{folder}:")
+        for item in items:
+            print(f"  - {item['file']}")
 
     with app.app_context():
         db.create_all()

--- a/site/checklist_blueprint.py
+++ b/site/checklist_blueprint.py
@@ -46,19 +46,6 @@ def list_folders():
     return jsonify(folders)
 
 
-@bp.route('/api/folders')
-def list_folders():
-    try:
-        folders = [
-            d for d in os.listdir(BASE_DIR)
-            if os.path.isdir(os.path.join(BASE_DIR, d))
-        ]
-    except OSError as e:
-        return jsonify({'error': str(e)}), 500
-    folders.sort()
-    return jsonify(folders)
-
-
 @bp.route('/api/files')
 def list_files():
     folder = request.args.get('folder', '')

--- a/site/json_api/list_checklists.py
+++ b/site/json_api/list_checklists.py
@@ -1,0 +1,74 @@
+import os
+import json
+from typing import Dict, List, Any
+
+BASE_DIR = os.path.dirname(__file__)
+FOLDERS = [
+    "Posto01_Oficina",
+    "Posto02_Oficina",
+    "Posto02_Oficina_Inspetor",
+    "Posto03_Pre_montagem_01",
+    "Posto03_Pre_montagem_01_Inspetor",
+    "POSTO_04_BARRAMENTO",
+    "POSTO_04_BARRAMENTO_Inspetor",
+    "Posto05_cablagem_01",
+    "Posto05_cablagem_01_inspetor",
+    "Posto06_Pre_montagem_02",
+    "Posto06_Pre_montagem_02_inspetor",
+    "POSTO06_1_06Cablagem02",
+    "POSTO06_1_06Cablagem02_inspetor",
+    "posto08_IQM",
+    "posto08_IQE",
+    "POSTO08_TESTE",
+    "EXPEDICAO",
+    "CHECKLIST_FINAL",
+]
+
+def collect_checklists() -> Dict[str, List[Dict[str, Any]]]:
+    """Return a mapping of folder names to their JSON checklist contents.
+
+    Any directory that does not exist is skipped. Each entry contains the
+    filename and the parsed JSON data. Files that cannot be decoded as JSON are
+    ignored. The function is useful for debugging or quick inspection of the
+    pipeline.
+    """
+    result: Dict[str, List[Dict[str, Any]]] = {}
+    for folder in FOLDERS:
+        path = os.path.join(BASE_DIR, folder)
+        if not os.path.isdir(path):
+            continue
+        entries: List[Dict[str, Any]] = []
+        for fname in os.listdir(path):
+            if not fname.endswith(".json"):
+                continue
+            fpath = os.path.join(path, fname)
+            try:
+                with open(fpath, "r", encoding="utf-8") as fp:
+                    data = json.load(fp)
+            except Exception:
+                continue
+            entries.append({"file": fname, "data": data})
+        result[folder] = entries
+    return result
+
+
+def main() -> None:
+    """Command line helper that prints discovered checklists."""
+    import argparse
+    parser = argparse.ArgumentParser(description="List checklist JSON files")
+    parser.add_argument(
+        "--show", action="store_true", help="Print JSON content instead of just filenames"
+    )
+    args = parser.parse_args()
+    data = collect_checklists()
+    for folder, items in data.items():
+        print(folder + ":")
+        for item in items:
+            if args.show:
+                print(json.dumps(item["data"], ensure_ascii=False, indent=2))
+            else:
+                print(f"  - {item['file']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- automatically list JSON checklist files when starting the Flask app
- remove duplicate checklist folder endpoint to prevent startup collision

## Testing
- `pytest -q`
- `timeout 5 python site/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a376e616c0832fa51daff69c0d5fe1