### PR TITLE
feat: exibir status de logistica nos checklists

### DIFF
--- a/site/app.py
+++ b/site/app.py
@@ -9,7 +9,7 @@ from json_api import bp as json_api_bp, merge_directory, move_matching_checklist
 from checklist_blueprint import bp as checklist_bp
 from flask_login import LoginManager, login_user, current_user
 from flask import Flask, request
-from sqlalchemy import inspect
+from sqlalchemy import inspect, text
 
 def create_app():
     app = Flask(__name__, template_folder="projetista/templates")
@@ -62,17 +62,17 @@ def create_app():
             cols = [c['name'] for c in insp.get_columns('solicitacao')]
             if 'status' not in cols:
                 db.session.execute(
-                    "ALTER TABLE solicitacao ADD COLUMN status VARCHAR(20) DEFAULT 'analise'"
+                    text("ALTER TABLE solicitacao ADD COLUMN status VARCHAR(20) DEFAULT 'analise'")
                 )
                 db.session.commit()
             if 'pendencias' not in cols:
                 db.session.execute(
-                    "ALTER TABLE solicitacao ADD COLUMN pendencias TEXT"
+                    text("ALTER TABLE solicitacao ADD COLUMN pendencias TEXT")
                 )
                 db.session.commit()
             if 'data_entrega' not in cols:
                 db.session.execute(
-                    "ALTER TABLE solicitacao ADD COLUMN data_entrega DATE"
+                    text("ALTER TABLE solicitacao ADD COLUMN data_entrega DATE")
                 )
                 db.session.commit()
 
@@ -80,12 +80,12 @@ def create_app():
             cols = [c['name'] for c in insp.get_columns('item')]
             if 'status' not in cols:
                 db.session.execute(
-                    "ALTER TABLE item ADD COLUMN status VARCHAR(20) DEFAULT 'Nao iniciada'"
+                    text("ALTER TABLE item ADD COLUMN status VARCHAR(20) DEFAULT 'Nao iniciada'")
                 )
                 db.session.commit()
             if 'previsao_entrega' not in cols:
                 db.session.execute(
-                    "ALTER TABLE item ADD COLUMN previsao_entrega DATE"
+                    text("ALTER TABLE item ADD COLUMN previsao_entrega DATE")
                 )
                 db.session.commit()
 
@@ -98,5 +98,8 @@ def create_app():
     return app
 
 if __name__ == '__main__':
+    from json_api import list_checklists
+
+    list_checklists.main()
     app = create_app()
     app.run(debug=True, host='0.0.0.0')

--- a/site/checklist_blueprint.py
+++ b/site/checklist_blueprint.py
@@ -2,7 +2,8 @@ import os
 import re
 import json
 from datetime import datetime
-from flask import Blueprint, jsonify, render_template, request
+from flask import Blueprint, jsonify, request
+from json_api.list_checklists import FOLDERS, humanize_folder
 
 bp = Blueprint('checklist', __name__, template_folder='templates')
 
@@ -23,40 +24,33 @@ def _validate_part(part: str) -> bool:
     return bool(ALLOWED_RE.fullmatch(part))
 
 
-@bp.route('/', strict_slashes=False)
-def index():
-    """Renderiza a página principal de checklists.
+@bp.route('/api/folders')
+def list_folders():
+    """Return available checklist folders with friendly labels.
 
-    strict_slashes=False permite acessar tanto
-    "/projetista/checklist" quanto "/projetista/checklist/".
+    The folders are returned in the predefined order from ``FOLDERS`` and
+    enumerated starting at 1. Missing folders are skipped; any extra folders on
+    disk are appended at the end in alphabetical order.
     """
-    return render_template('checklist.html')
-
-
-@bp.route('/api/folders')
-def list_folders():
     try:
-        folders = [
+        available = [
             d for d in os.listdir(BASE_DIR)
             if os.path.isdir(os.path.join(BASE_DIR, d))
         ]
     except OSError as e:
         return jsonify({'error': str(e)}), 500
-    folders.sort()
-    return jsonify(folders)
 
+    ordered = [f for f in FOLDERS if f in available]
+    extras = sorted(
+        [d for d in available if d not in FOLDERS and not d.startswith('__')]
+    )
+    ordered.extend(extras)
 
-@bp.route('/api/folders')
-def list_folders():
-    try:
-        folders = [
-            d for d in os.listdir(BASE_DIR)
-            if os.path.isdir(os.path.join(BASE_DIR, d))
-        ]
-    except OSError as e:
-        return jsonify({'error': str(e)}), 500
-    folders.sort()
-    return jsonify(folders)
+    result = []
+    for idx, folder in enumerate(ordered, 1):
+        label = f"{idx:02d} - {humanize_folder(folder)}"
+        result.append({'path': folder, 'label': label})
+    return jsonify(result)
 
 
 @bp.route('/api/files')
@@ -93,6 +87,33 @@ def get_file():
         return jsonify({'error': 'Parâmetros inválidos'}), 400
     try:
         file_path = safe_join(BASE_DIR, folder, name)
+        st = os.stat(file_path)
+        if st.st_size > MAX_FILE_SIZE:
+            return jsonify({'error': 'Arquivo muito grande'}), 413
+        with open(file_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        return jsonify(data)
+    except FileNotFoundError:
+        return jsonify({'error': 'Arquivo não encontrado'}), 404
+    except PermissionError:
+        return jsonify({'error': 'Permissão negada'}), 403
+    except json.JSONDecodeError:
+        return jsonify({'error': 'JSON inválido'}), 400
+    except OSError as e:
+        return jsonify({'error': str(e)}), 500
+
+
+@bp.route('/raw/<path:filepath>')
+def get_any_file(filepath: str):
+    """Retorna o conteúdo de um arquivo de checklist no escopo."""
+    parts = filepath.split('/')
+    if not parts or not parts[-1].lower().endswith('.json'):
+        return jsonify({'error': 'Arquivo inválido'}), 400
+    folders, filename = parts[:-1], parts[-1]
+    if any(not _validate_part(p) for p in folders) or not _validate_part(filename[:-5]):
+        return jsonify({'error': 'Parâmetros inválidos'}), 400
+    try:
+        file_path = safe_join(BASE_DIR, *folders, filename)
         st = os.stat(file_path)
         if st.st_size > MAX_FILE_SIZE:
             return jsonify({'error': 'Arquivo muito grande'}), 413

--- a/site/json_api/POSTO08_TESTE/checklist_TESTE.json
+++ b/site/json_api/POSTO08_TESTE/checklist_TESTE.json
@@ -1,0 +1,282 @@
+{
+  "obra": "PROJETO_TESTE",
+  "ano": "2025",
+  "posto08_teste": {
+    "inspetor": "muri",
+    "itens": [
+      {
+        "numero": 8301,
+        "pergunta": "Responsável",
+        "respostas": {
+          "inspetor": [
+            "tomtom"
+          ]
+        }
+      },
+      {
+        "numero": 8302,
+        "pergunta": "Altitude em relação ao nivel do mar",
+        "respostas": {
+          "inspetor": [
+            "56"
+          ]
+        }
+      },
+      {
+        "numero": 8303,
+        "pergunta": "Tipo de ambiente",
+        "respostas": {
+          "inspetor": [
+            "b9m"
+          ]
+        }
+      },
+      {
+        "numero": 8304,
+        "pergunta": "Temperatura Ambiente",
+        "respostas": {
+          "inspetor": [
+            "67"
+          ]
+        }
+      },
+      {
+        "numero": 8305,
+        "pergunta": "Humidade relatíva",
+        "respostas": {
+          "inspetor": [
+            "88"
+          ]
+        }
+      },
+      {
+        "numero": 8306,
+        "pergunta": "Tensão de comando",
+        "respostas": {
+          "inspetor": [
+            "222"
+          ]
+        }
+      },
+      {
+        "numero": 8307,
+        "pergunta": "Tensão circuito auxiliar",
+        "respostas": {
+          "inspetor": [
+            "23"
+          ]
+        }
+      },
+      {
+        "numero": 8308,
+        "pergunta": "Tensão circuito de força",
+        "respostas": {
+          "inspetor": [
+            "222"
+          ]
+        }
+      },
+      {
+        "numero": 8309,
+        "pergunta": "4.2 - Comando x Terra",
+        "respostas": {
+          "inspetor": [
+            "v",
+            "23",
+            "v",
+            "34",
+            "C"
+          ]
+        }
+      },
+      {
+        "numero": 8310,
+        "pergunta": "4.3 - Força - Fase A x BC Terra",
+        "respostas": {
+          "inspetor": [
+            "45",
+            "u88",
+            "56",
+            "34",
+            "C"
+          ]
+        }
+      },
+      {
+        "numero": 8311,
+        "pergunta": "4.4 - Força - Fase B x AC Terra",
+        "respostas": {
+          "inspetor": [
+            "y",
+            "66",
+            "mm",
+            "76",
+            "C"
+          ]
+        }
+      },
+      {
+        "numero": 8312,
+        "pergunta": "4.5 - Força - Fase C x AB Terra",
+        "respostas": {
+          "inspetor": [
+            "vb",
+            "22",
+            "bv",
+            "67",
+            "C"
+          ]
+        }
+      },
+      {
+        "numero": 8313,
+        "pergunta": "4.6 - Força - Fase ABC x Terra",
+        "respostas": {
+          "inspetor": [
+            "mn",
+            "222",
+            "mn",
+            "55",
+            "C"
+          ]
+        }
+      },
+      {
+        "numero": 8314,
+        "pergunta": "Multimedidores",
+        "respostas": {
+          "inspetor": [
+            "C"
+          ]
+        }
+      },
+      {
+        "numero": 8315,
+        "pergunta": "Controladores",
+        "respostas": {
+          "inspetor": [
+            "C"
+          ]
+        }
+      },
+      {
+        "numero": 8316,
+        "pergunta": "Drives",
+        "respostas": {
+          "inspetor": [
+            "C"
+          ]
+        }
+      },
+      {
+        "numero": 8317,
+        "pergunta": "Monitores",
+        "respostas": {
+          "inspetor": [
+            "C"
+          ]
+        }
+      },
+      {
+        "numero": 8318,
+        "pergunta": "Sensores",
+        "respostas": {
+          "inspetor": [
+            "C"
+          ]
+        }
+      },
+      {
+        "numero": 8319,
+        "pergunta": "IHMs",
+        "respostas": {
+          "inspetor": [
+            "C"
+          ]
+        }
+      },
+      {
+        "numero": 8320,
+        "pergunta": "Timers",
+        "respostas": {
+          "inspetor": [
+            "C"
+          ]
+        }
+      },
+      {
+        "numero": 8321,
+        "pergunta": "Dispositivos de proteção ajustável",
+        "respostas": {
+          "inspetor": [
+            "C"
+          ]
+        }
+      },
+      {
+        "numero": 8322,
+        "pergunta": "Sinalizadores",
+        "respostas": {
+          "inspetor": [
+            "C"
+          ]
+        }
+      },
+      {
+        "numero": 8323,
+        "pergunta": "Status à campo",
+        "respostas": {
+          "inspetor": [
+            "C"
+          ]
+        }
+      },
+      {
+        "numero": 8324,
+        "pergunta": "Leituras",
+        "respostas": {
+          "inspetor": [
+            "C"
+          ]
+        }
+      },
+      {
+        "numero": 8325,
+        "pergunta": "Intertravamentos",
+        "respostas": {
+          "inspetor": [
+            "C"
+          ]
+        }
+      },
+      {
+        "numero": 8326,
+        "pergunta": "Lógica de acionamento",
+        "respostas": {
+          "inspetor": [
+            "C"
+          ]
+        }
+      },
+      {
+        "numero": 8327,
+        "pergunta": "Programa",
+        "respostas": {
+          "inspetor": [
+            "C"
+          ]
+        }
+      },
+      {
+        "numero": 8328,
+        "pergunta": "Tensão das saídas à campo",
+        "respostas": {
+          "inspetor": [
+            "C"
+          ]
+        }
+      }
+    ]
+  }
+}
+

--- a/site/json_api/list_checklists.py
+++ b/site/json_api/list_checklists.py
@@ -1,0 +1,98 @@
+import os
+import re
+import json
+from typing import Dict, List, Any
+
+BASE_DIR = os.path.dirname(__file__)
+FOLDERS = [
+    "Posto01_Oficina",
+    "Posto02_Oficina",
+    "Posto02_Oficina_Inspetor",
+    "Posto03_Pre_montagem_01",
+    "Posto03_Pre_montagem_01_Inspetor",
+    "POSTO_04_BARRAMENTO",
+    "POSTO_04_BARRAMENTO_Inspetor",
+    "Posto05_cablagem_01",
+    "Posto05_cablagem_01_inspetor",
+    "Posto06_Pre_montagem_02",
+    "Posto06_Pre_montagem_02_inspetor",
+    "POSTO06_1_06Cablagem02",
+    "POSTO06_1_06Cablagem02_inspetor",
+    "posto08_IQM",
+    "posto08_IQE",
+    "POSTO08_TESTE",
+    "EXPEDICAO",
+    "CHECKLIST_FINAL",
+]
+
+
+def humanize_folder(name: str) -> str:
+    """Return a human friendly representation of ``name``.
+
+    Examples
+    --------
+    >>> humanize_folder("Posto01_Oficina")
+    'Posto 01 Oficina'
+    >>> humanize_folder("POSTO08_TESTE")
+    'Posto 08 Teste'
+    """
+    text = name.replace("_", " ")
+
+    def repl(match: re.Match) -> str:
+        return f"Posto {int(match.group(1)):02d}"
+
+    text = re.sub(r"posto\s*(\d+)", repl, text, flags=re.I)
+    text = text.title()
+    # Preserve acronyms in upper-case
+    for acr in ("IQM", "IQE"):
+        text = text.replace(acr.title(), acr)
+    return text
+
+def collect_checklists() -> Dict[str, List[Dict[str, Any]]]:
+    """Return a mapping of folder names to their JSON checklist contents.
+
+    Any directory that does not exist is skipped. Each entry contains the
+    filename and the parsed JSON data. Files that cannot be decoded as JSON are
+    ignored. The function is useful for debugging or quick inspection of the
+    pipeline.
+    """
+    result: Dict[str, List[Dict[str, Any]]] = {}
+    for folder in FOLDERS:
+        path = os.path.join(BASE_DIR, folder)
+        if not os.path.isdir(path):
+            continue
+        entries: List[Dict[str, Any]] = []
+        for fname in os.listdir(path):
+            if not fname.endswith(".json"):
+                continue
+            fpath = os.path.join(path, fname)
+            try:
+                with open(fpath, "r", encoding="utf-8") as fp:
+                    data = json.load(fp)
+            except Exception:
+                continue
+            entries.append({"file": fname, "data": data})
+        result[folder] = entries
+    return result
+
+
+def main() -> None:
+    """Command line helper that prints discovered checklists."""
+    import argparse
+    parser = argparse.ArgumentParser(description="List checklist JSON files")
+    parser.add_argument(
+        "--show", action="store_true", help="Print JSON content instead of just filenames"
+    )
+    args = parser.parse_args()
+    data = collect_checklists()
+    for folder, items in data.items():
+        print(folder + ":")
+        for item in items:
+            if args.show:
+                print(json.dumps(item["data"], ensure_ascii=False, indent=2))
+            else:
+                print(f"  - {item['file']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -402,34 +402,8 @@ def api_compras(id):
 @bp.route('/checklist')
 @login_required
 def checklist_list():
-    """Lista os checklists agrupados por obra.
-
-    Também identifica o checklist anterior de cada obra para que o
-    usuário possa visualizar as diferenças entre versões.
-    """
-    projetos = {}
-    if os.path.isdir(CHECKLIST_DIR):
-        for nome in os.listdir(CHECKLIST_DIR):
-            if not nome.lower().endswith('.json'):
-                continue
-            caminho = os.path.join(CHECKLIST_DIR, nome)
-            try:
-                with open(caminho, encoding='utf-8') as f:
-                    dados = json.load(f)
-                obra = dados.get('obra', 'Desconhecida') or 'Desconhecida'
-            except Exception:
-                obra = 'Desconhecida'
-            projetos.setdefault(obra, []).append({'filename': nome})
-
-    # Ordena os arquivos de cada obra e define o checklist anterior
-    for obra, arquivos in projetos.items():
-        arquivos.sort(key=lambda a: a['filename'])
-        for idx, arq in enumerate(arquivos, start=1):
-            arq['revisao'] = idx
-            if idx > 1:
-                arq['diff'] = arquivos[idx - 1]['filename']
-
-    return render_template('checklist_list.html', projetos=projetos)
+    """Renderiza a interface de visualização dos checklists."""
+    return render_template('checklist.html')
 
 
 @bp.route('/checklist/<path:filename>')

--- a/site/templates/checklist.html
+++ b/site/templates/checklist.html
@@ -62,6 +62,7 @@ pre{background:#111;padding:10px;overflow:auto;}
 <option value="produção">Produção</option>
 <option value="montador">Montador</option>
 <option value="inspetor">Inspetor</option>
+<option value="logistica">Logística</option>
 </select>
 </div>
 <div id="etapaView"></div>
@@ -69,12 +70,13 @@ pre{background:#111;padding:10px;overflow:auto;}
 </div>
 </div>
 <script>
-let folders=[], files=[], currentFolder='', currentFileName='', currentFileData=null;
+let folders=[], files=[], currentFolder='', currentFolderLabel='', currentFileName='', currentFileData=null;
 let filters={text:'',status:'',papel:''};
 let paginationState={};
 
 function updatePath(){
-    document.getElementById('currentPath').textContent=currentFolder+(currentFileName?`/${currentFileName}`:'');
+    const base=currentFolderLabel||currentFolder;
+    document.getElementById('currentPath').textContent=base+(currentFileName?`/${currentFileName}`:'');
 }
 
 function cellStatus(arr){
@@ -91,11 +93,12 @@ function itemAggregate(item){
     const p=cellStatus(r['produção']);
     const m=cellStatus(r.montador);
     const i=cellStatus(r.inspetor);
+    const l=cellStatus(r.logistica);
     let overall='-';
-    if([s,p,m,i].includes('NC')) overall='NC';
-    else if([s,p,m,i].includes('C')) overall='C';
+    if([s,p,m,i,l].includes('NC')) overall='NC';
+    else if([s,p,m,i,l].includes('C')) overall='C';
     const hasDoubleNC=(m==='NC' && i==='NC');
-    return {s,p,m,i,overall,hasDoubleNC};
+    return {s,p,m,i,l,overall,hasDoubleNC};
 }
 
 function applyGlobalFilters(items){
@@ -104,7 +107,7 @@ function applyGlobalFilters(items){
         const agg=itemAggregate(it);
         if(filters.status){
             if(filters.papel){
-                const map={suprimento:'s','produção':'p',montador:'m',inspetor:'i'};
+                const map={suprimento:'s','produção':'p',montador:'m',inspetor:'i',logistica:'l'};
                 if(agg[map[filters.papel]]!==filters.status) return false;
             } else if(agg.overall!==filters.status) return false;
         }
@@ -131,12 +134,13 @@ function renderSectionCard(key, title, items){
                    `<td><span class="badge ${agg.p==='NC'?'bad':agg.p==='C'?'ok':'nil'}">${agg.p}</span></td>`+
                    `<td><span class="badge ${agg.m==='NC'?'bad':agg.m==='C'?'ok':'nil'}">${agg.m}</span></td>`+
                    `<td><span class="badge ${agg.i==='NC'?'bad':agg.i==='C'?'ok':'nil'}">${agg.i}</span></td>`+
+                   `<td><span class="badge ${agg.l==='NC'?'bad':agg.l==='C'?'ok':'nil'}">${agg.l}</span></td>`+
                    `<td><span class="badge ${agg.overall==='NC'?'bad':agg.overall==='C'?'ok':'nil'}">${agg.overall}</span></td></tr>`;
         }).join('');
     }
     let html=`<div class="card"><h3>${title}</h3>`+
              `<div>Itens: ${total} | %C ${pct(c)} | %NC ${pct(nc)}</div>`+
-             `<table><tr><th>Nº</th><th>Pergunta</th><th>Supr.</th><th>Prod.</th><th>Mont.</th><th>Insp.</th><th>Status</th></tr>`+
+             `<table><tr><th>Nº</th><th>Pergunta</th><th>Supr.</th><th>Prod.</th><th>Mont.</th><th>Insp.</th><th>Log.</th><th>Status</th></tr>`+
              `${rowsFor(page)}</table>`;
     if(pages>1){
         html+=`<div class="pagination">`;
@@ -231,24 +235,28 @@ function renderEtapas(){
     });
 }
 
+const foldersUrl = "{{ url_for('checklist.list_folders') }}";
+const filesUrl = "{{ url_for('checklist.list_files') }}";
+const fileUrl = "{{ url_for('checklist.get_file') }}";
+
 function loadFolders(){
-    fetch('api/folders').then(r=>r.json()).then(data=>{folders=data;renderFolders();});
+    fetch(foldersUrl).then(r=>r.json()).then(data=>{folders=data;renderFolders();});
 }
 function renderFolders(){
     const term=document.getElementById('folderFilter').value.toLowerCase();
     const ul=document.getElementById('folderList');
     ul.innerHTML='';
-    folders.filter(f=>f.toLowerCase().includes(term)).forEach(f=>{
+    folders.filter(f=>f.label.toLowerCase().includes(term)).forEach(f=>{
         const li=document.createElement('li');
-        li.textContent=f;li.tabIndex=0;
-        if(f===currentFolder) li.classList.add('selected');
-        li.onclick=()=>{currentFolder=f;currentFileName='';loadFiles();updatePath();};
+        li.textContent=f.label;li.tabIndex=0;
+        if(f.path===currentFolder) li.classList.add('selected');
+        li.onclick=()=>{currentFolder=f.path;currentFolderLabel=f.label;currentFileName='';loadFiles();updatePath();};
         li.onkeyup=e=>{if(e.key==='Enter')li.click();};
         ul.appendChild(li);
     });
 }
 function loadFiles(){
-    fetch(`api/files?folder=${encodeURIComponent(currentFolder)}`).then(r=>r.json()).then(data=>{files=data;renderFiles();});
+    fetch(`${filesUrl}?folder=${encodeURIComponent(currentFolder)}`).then(r=>r.json()).then(data=>{files=data;renderFiles();});
 }
 function renderFiles(){
     const term=document.getElementById('fileFilter').value.toLowerCase();
@@ -264,7 +272,7 @@ function renderFiles(){
     });
 }
 function loadFile(name){
-    fetch(`api/file?folder=${encodeURIComponent(currentFolder)}&name=${encodeURIComponent(name)}`)
+    fetch(`${fileUrl}?folder=${encodeURIComponent(currentFolder)}&name=${encodeURIComponent(name)}`)
         .then(r=>r.json())
         .then(data=>{currentFileData=data;currentFileName=name;document.getElementById('jsonView').textContent=JSON.stringify(data,null,2);renderEtapas();updatePath();renderFiles();});
 }


### PR DESCRIPTION
## Summary
- mostrar status de logística nos itens de checklist
- permitir filtro por papel de logística
- ordenar pastas de checklist com rótulos numerados e legíveis
- incluir checklist de Posto 08 Teste
- fix SQL migrations for SQLAlchemy 2

## Testing
- `pytest -q`
- `python site/json_api/list_checklists.py`
- `timeout 5 python site/app.py`
- `python - <<'PY' from app import create_app; app=create_app(); client=app.test_client(); folders = client.get('/projetista/checklist/api/folders').json; files = client.get('/projetista/checklist/api/files', query_string={'folder':'POSTO08_TESTE'}).json; content = client.get('/projetista/checklist/api/file', query_string={'folder':'POSTO08_TESTE','name':'checklist_TESTE.json'}).json; print('folders', folders); print('files', files); print('keys', content.keys()); print('first item', content['posto08_teste']['itens'][0]['pergunta'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a376e616c0832fa51daff69c0d5fe1