### PR TITLE
feat: add photo listing and capture

### DIFF
--- a/AppEstoque/app/src/main/AndroidManifest.xml
+++ b/AppEstoque/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <!-- 1) Permissão de Internet -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.CAMERA"/>
 
     <application
 

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/ApiService.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/ApiService.kt
@@ -1,8 +1,12 @@
 package com.example.apestoque.data
 
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Multipart
 import retrofit2.http.POST
+import retrofit2.http.Part
 import retrofit2.http.Path
 
 interface ApiService {
@@ -25,6 +29,17 @@ interface ApiService {
     suspend fun enviarResultadoInspecao(
         @Path("id") id: Int,
         @Body body: InspecaoResultadoRequest
+    )
+
+    @GET("api/fotos")
+    suspend fun listarFotos(): List<FotoNode>
+
+    @Multipart
+    @POST("api/fotos/upload")
+    suspend fun enviarFoto(
+        @Part("ano") ano: RequestBody,
+        @Part("obra") obra: RequestBody,
+        @Part foto: MultipartBody.Part,
     )
 }
 

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/FotoNode.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/FotoNode.kt
@@ -1,0 +1,6 @@
+package com.example.apestoque.data
+
+data class FotoNode(
+    val name: String,
+    val children: List<FotoNode>? = null
+)

--- a/AppEstoque/app/src/main/java/com/example/apestoque/fragments/CameraFragment.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/fragments/CameraFragment.kt
@@ -1,18 +1,165 @@
 package com.example.apestoque.fragments
 
+import android.app.AlertDialog
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
+import android.widget.ExpandableListView
+import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import com.example.apestoque.R
+import com.example.apestoque.data.FotoNode
+import com.example.apestoque.data.NetworkModule
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import kotlinx.coroutines.launch
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import android.widget.SimpleExpandableListAdapter
 
 class CameraFragment : Fragment() {
+
+    private lateinit var listView: ExpandableListView
+    private lateinit var btnCamera: FloatingActionButton
+
+    private var currentPhoto: File? = null
+    private var anoSelecionado: String = ""
+    private var obraSelecionada: String = ""
+
+    private val takePicture = registerForActivityResult(androidx.activity.result.contract.ActivityResultContracts.TakePicture()) { success ->
+        if (success && currentPhoto != null) {
+            uploadPhoto(currentPhoto!!, anoSelecionado, obraSelecionada)
+        }
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View? {
-        return inflater.inflate(R.layout.fragment_camera, container, false)
+    ): View {
+        val view = inflater.inflate(R.layout.fragment_camera, container, false)
+        listView = view.findViewById(R.id.fotoList)
+        btnCamera = view.findViewById(R.id.btnCamera)
+
+        btnCamera.setOnClickListener { showInputDialog() }
+
+        loadPhotos()
+
+        return view
+    }
+
+    private fun showInputDialog() {
+        val dialogView = layoutInflater.inflate(R.layout.dialog_save_photo, null)
+        val edtAno = dialogView.findViewById<EditText>(R.id.edtAno)
+        val edtObra = dialogView.findViewById<EditText>(R.id.edtObra)
+        AlertDialog.Builder(requireContext())
+            .setTitle("Salvar foto")
+            .setView(dialogView)
+            .setPositiveButton("OK") { _, _ ->
+                anoSelecionado = edtAno.text.toString()
+                obraSelecionada = edtObra.text.toString()
+                openCamera()
+            }
+            .setNegativeButton("Cancelar", null)
+            .show()
+    }
+
+    private fun openCamera() {
+        val context = requireContext()
+        val photoDir = context.getExternalFilesDir(null) ?: return
+        val timeStamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+        val photoFile = File(photoDir, "IMG_${'$'}timeStamp.jpg")
+        currentPhoto = photoFile
+        val uri = FileProvider.getUriForFile(context, "${'$'}{context.packageName}.fileprovider", photoFile)
+        takePicture.launch(uri)
+    }
+
+    private fun uploadPhoto(file: File, ano: String, obra: String) {
+        val api = NetworkModule.api(requireContext())
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val anoBody = ano.toRequestBody("text/plain".toMediaType())
+                val obraBody = obra.toRequestBody("text/plain".toMediaType())
+                val reqFile = file.asRequestBody("image/jpeg".toMediaType())
+                val part = MultipartBody.Part.createFormData("foto", file.name, reqFile)
+                api.enviarFoto(anoBody, obraBody, part)
+                loadPhotos()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
+
+    private fun loadPhotos() {
+        val api = NetworkModule.api(requireContext())
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val tree = api.listarFotos()
+                val data = flatten(tree, "")
+                val groups = data.keys.sorted()
+                val groupData = groups.map { mapOf("NAME" to it) }
+                val childData = groups.map { dir ->
+                    data[dir]!!.sorted().map { mapOf("NAME" to it) }
+                }
+                val adapter = SimpleExpandableListAdapter(
+                    context,
+                    groupData,
+                    android.R.layout.simple_expandable_list_item_1,
+                    arrayOf("NAME"),
+                    intArrayOf(android.R.id.text1),
+                    childData,
+                    android.R.layout.simple_list_item_1,
+                    arrayOf("NAME"),
+                    intArrayOf(android.R.id.text1)
+                )
+                listView.setAdapter(adapter)
+                listView.setOnChildClickListener { _, _, groupPosition, childPosition, _ ->
+                    val dir = groups[groupPosition]
+                    val fileName = data[dir]!![childPosition]
+                    openImage(dir, fileName)
+                    true
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
+
+    private fun flatten(nodes: List<FotoNode>, base: String): MutableMap<String, MutableList<String>> {
+        val map = mutableMapOf<String, MutableList<String>>()
+        for (node in nodes) {
+            val currentPath = if (base.isEmpty()) node.name else "$base/${node.name}"
+            if (node.children.isNullOrEmpty()) {
+                val dir = base
+                if (dir.isNotEmpty()) {
+                    map.getOrPut(dir) { mutableListOf() }.add(node.name)
+                }
+            } else {
+                val childMap = flatten(node.children, currentPath)
+                for ((k, v) in childMap) {
+                    val list = map.getOrPut(k) { mutableListOf() }
+                    list.addAll(v)
+                }
+            }
+        }
+        return map
+    }
+
+    private fun openImage(dir: String, file: String) {
+        val prefs = requireContext().getSharedPreferences("app", Context.MODE_PRIVATE)
+        val ip = prefs.getString("api_ip", "192.168.0.135")
+        val url = "http://$ip:5000/projetista/api/fotos/raw/${Uri.encode("$dir/$file")}".replace("%2F", "/")
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        startActivity(intent)
     }
 }

--- a/AppEstoque/app/src/main/res/layout/dialog_save_photo.xml
+++ b/AppEstoque/app/src/main/res/layout/dialog_save_photo.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <EditText
+        android:id="@+id/edtAno"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Ano" />
+
+    <EditText
+        android:id="@+id/edtObra"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Obra" />
+</LinearLayout>

--- a/AppEstoque/app/src/main/res/layout/fragment_camera.xml
+++ b/AppEstoque/app/src/main/res/layout/fragment_camera.xml
@@ -1,12 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="center">
+    android:orientation="vertical">
 
-    <TextView
+    <ExpandableListView
+        android:id="@+id/fotoList"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/btnCamera"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Camera"
-        android:textSize="24sp" />
-</FrameLayout>
+        android:layout_gravity="end|bottom"
+        android:layout_margin="16dp"
+        app:srcCompat="@android:drawable/ic_menu_camera" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- expose API to list, upload and serve photo files from configurable FOTOS_DIR
- show photos in expandable list and allow capturing/uploading images from camera
- add dialog to select year and obra before taking pictures

## Testing
- `python -m py_compile Checklist-Estoque/site/projetista/__init__.py`
- `./gradlew test` (fails: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68a749ba2d1c832fa04c6657b114b248