### PR TITLE
feat: add photo listing and capture

### DIFF
--- a/AppEstoque/app/src/main/AndroidManifest.xml
+++ b/AppEstoque/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <!-- 1) Permissão de Internet -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.CAMERA"/>
 
     <application
 

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/ApiService.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/ApiService.kt
@@ -1,8 +1,12 @@
 package com.example.apestoque.data
 
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Multipart
 import retrofit2.http.POST
+import retrofit2.http.Part
 import retrofit2.http.Path
 
 interface ApiService {
@@ -25,6 +29,17 @@ interface ApiService {
     suspend fun enviarResultadoInspecao(
         @Path("id") id: Int,
         @Body body: InspecaoResultadoRequest
+    )
+
+    @GET("api/fotos")
+    suspend fun listarFotos(): List<FotoNode>
+
+    @Multipart
+    @POST("api/fotos/upload")
+    suspend fun enviarFoto(
+        @Part("ano") ano: RequestBody,
+        @Part("obra") obra: RequestBody,
+        @Part foto: MultipartBody.Part,
     )
 }
 

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/FotoNode.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/FotoNode.kt
@@ -1,0 +1,6 @@
+package com.example.apestoque.data
+
+data class FotoNode(
+    val name: String,
+    val children: List<FotoNode>? = null
+)

--- a/AppEstoque/app/src/main/java/com/example/apestoque/fragments/CameraFragment.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/fragments/CameraFragment.kt
@@ -1,18 +1,166 @@
 package com.example.apestoque.fragments
 
+import android.app.AlertDialog
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
+import android.widget.ExpandableListView
+import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import com.example.apestoque.R
+import com.example.apestoque.data.FotoNode
+import com.example.apestoque.data.NetworkModule
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import kotlinx.coroutines.launch
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import android.widget.SimpleExpandableListAdapter
 
 class CameraFragment : Fragment() {
+
+    private lateinit var listView: ExpandableListView
+    private lateinit var btnCamera: FloatingActionButton
+
+    private var currentPhoto: File? = null
+    private var anoSelecionado: String = ""
+    private var obraSelecionada: String = ""
+
+    private val takePicture = registerForActivityResult(androidx.activity.result.contract.ActivityResultContracts.TakePicture()) { success ->
+        if (success && currentPhoto != null) {
+            uploadPhoto(currentPhoto!!, anoSelecionado, obraSelecionada)
+        }
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View? {
-        return inflater.inflate(R.layout.fragment_camera, container, false)
+    ): View {
+        val view = inflater.inflate(R.layout.fragment_camera, container, false)
+        listView = view.findViewById(R.id.fotoList)
+        btnCamera = view.findViewById(R.id.btnCamera)
+
+        btnCamera.setOnClickListener { showInputDialog() }
+
+        loadPhotos()
+
+        return view
+    }
+
+    private fun showInputDialog() {
+        val dialogView = layoutInflater.inflate(R.layout.dialog_save_photo, null)
+        val edtAno = dialogView.findViewById<EditText>(R.id.edtAno)
+        val edtObra = dialogView.findViewById<EditText>(R.id.edtObra)
+        AlertDialog.Builder(requireContext())
+            .setTitle("Salvar foto")
+            .setView(dialogView)
+            .setPositiveButton("OK") { _, _ ->
+                anoSelecionado = edtAno.text.toString()
+                obraSelecionada = edtObra.text.toString()
+                openCamera()
+            }
+            .setNegativeButton("Cancelar", null)
+            .show()
+    }
+
+    private fun openCamera() {
+        val context = requireContext()
+        val photoDir = context.getExternalFilesDir(null) ?: return
+        val timeStamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+        val photoFile = File(photoDir, "IMG_${'$'}timeStamp.jpg")
+        currentPhoto = photoFile
+        val uri = FileProvider.getUriForFile(context, "${'$'}{context.packageName}.fileprovider", photoFile)
+        takePicture.launch(uri)
+    }
+
+    private fun uploadPhoto(file: File, ano: String, obra: String) {
+        val api = NetworkModule.api(requireContext())
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val anoBody = ano.toRequestBody("text/plain".toMediaType())
+                val obraBody = obra.toRequestBody("text/plain".toMediaType())
+                val reqFile = file.asRequestBody("image/jpeg".toMediaType())
+                val part = MultipartBody.Part.createFormData("foto", file.name, reqFile)
+                api.enviarFoto(anoBody, obraBody, part)
+                loadPhotos()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
+
+    private fun loadPhotos() {
+        val api = NetworkModule.api(requireContext())
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val tree = api.listarFotos()
+                val data = flatten(tree, "")
+                val groups = data.keys.sorted()
+                val groupData = groups.map { mapOf("NAME" to it) }
+                val childData = groups.map { dir ->
+                    data[dir]!!.sorted().map { mapOf("NAME" to it) }
+                }
+                val adapter = SimpleExpandableListAdapter(
+                    context,
+                    groupData,
+                    android.R.layout.simple_expandable_list_item_1,
+                    arrayOf("NAME"),
+                    intArrayOf(android.R.id.text1),
+                    childData,
+                    android.R.layout.simple_list_item_1,
+                    arrayOf("NAME"),
+                    intArrayOf(android.R.id.text1)
+                )
+                listView.setAdapter(adapter)
+                listView.setOnChildClickListener { _, _, groupPosition, childPosition, _ ->
+                    val dir = groups[groupPosition]
+                    val fileName = data[dir]!![childPosition]
+                    openImage(dir, fileName)
+                    true
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
+
+    private fun flatten(nodes: List<FotoNode>, base: String): MutableMap<String, MutableList<String>> {
+        val map = mutableMapOf<String, MutableList<String>>()
+        for (node in nodes) {
+            val currentPath = if (base.isEmpty()) node.name else "$base/${node.name}"
+            if (node.children.isNullOrEmpty()) {
+                val dir = base
+                if (dir.isNotEmpty()) {
+                    map.getOrPut(dir) { mutableListOf() }.add(node.name)
+                }
+            } else {
+                val childMap = flatten(node.children, currentPath)
+                for ((k, v) in childMap) {
+                    val list = map.getOrPut(k) { mutableListOf() }
+                    list.addAll(v)
+                }
+            }
+        }
+        return map
+    }
+
+    private fun openImage(dir: String, file: String) {
+        val prefs = requireContext().getSharedPreferences("app", Context.MODE_PRIVATE)
+        val ip = prefs.getString("api_ip", "192.168.0.135")
+        val url = "http://$ip:5000/projetista/api/fotos/raw/${Uri.encode("$dir/$file")}".replace("%2F", "/")
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        startActivity(intent)
     }
 }

--- a/AppEstoque/app/src/main/res/layout/dialog_save_photo.xml
+++ b/AppEstoque/app/src/main/res/layout/dialog_save_photo.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <EditText
+        android:id="@+id/edtAno"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Ano" />
+
+    <EditText
+        android:id="@+id/edtObra"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Obra" />
+</LinearLayout>

--- a/AppEstoque/app/src/main/res/layout/fragment_camera.xml
+++ b/AppEstoque/app/src/main/res/layout/fragment_camera.xml
@@ -1,12 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="center">
+    android:orientation="vertical">
 
-    <TextView
+    <ExpandableListView
+        android:id="@+id/fotoList"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/btnCamera"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Camera"
-        android:textSize="24sp" />
-</FrameLayout>
+        android:layout_gravity="end|bottom"
+        android:layout_margin="16dp"
+        app:srcCompat="@android:drawable/ic_menu_camera" />
+
+</LinearLayout>

--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -11,6 +11,7 @@ from collections import Counter
 from flask import jsonify
 import os
 from datetime import datetime
+from werkzeug.utils import secure_filename
 
 bp = Blueprint('projetista', __name__)
 
@@ -23,6 +24,16 @@ CHECKLIST_DIR = os.environ.get(
 
 # Diretório base onde os projetos são armazenados no servidor
 BASE_PRODUCAO = r"F:\03 - ENGENHARIA\03 - PRODUCAO"
+
+# Diretório onde as fotos são salvas (pode ser sobrescrito via FOTOS_DIR)
+# Por padrão aponta para a estrutura de projetos utilizada no servidor
+FOTOS_DIR = os.environ.get(
+    "FOTOS_DIR",
+    r"F:\\03 - ENGENHARIA\\02 - PROJETOS"
+)
+
+# Garante que o diretório base exista para evitar erros de leitura
+os.makedirs(FOTOS_DIR, exist_ok=True)
 
 # Subpastas que devem ser criadas para cada obra
 SUBPASTAS_OBRA = [
@@ -636,4 +647,65 @@ def api_inspecao_resultado(id):
             item.verificado = item_data.get('verificado', False)
             item.faltante = item_data.get('faltante', 0)
     db.session.commit()
+    return jsonify({'ok': True})
+
+
+def _safe_join(root: str, *paths: str) -> str:
+    root = os.path.abspath(root)
+    path = os.path.abspath(os.path.join(root, *paths))
+    if not path.startswith(root + os.sep):
+        raise ValueError('Caminho inválido')
+    return path
+
+
+def _build_photo_tree(base: str) -> list:
+    tree = []
+    try:
+        entries = sorted(os.listdir(base))
+    except OSError:
+        return tree
+    for name in entries:
+        full = os.path.join(base, name)
+        if os.path.isdir(full):
+            tree.append({
+                'name': name,
+                'children': _build_photo_tree(full)
+            })
+        elif name.lower().endswith(('.jpg', '.jpeg')):
+            tree.append({'name': name})
+    return tree
+
+
+@bp.route('/api/fotos')
+def api_listar_fotos():
+    """Lista recursivamente as fotos em ``FOTOS_DIR``."""
+    return jsonify(_build_photo_tree(FOTOS_DIR))
+
+
+@bp.route('/api/fotos/raw/<path:filepath>')
+def api_foto_raw(filepath: str):
+    try:
+        file_path = _safe_join(FOTOS_DIR, filepath)
+    except ValueError:
+        return jsonify({'error': 'Caminho inválido'}), 400
+    if not os.path.isfile(file_path):
+        return jsonify({'error': 'Arquivo não encontrado'}), 404
+    return send_file(file_path)
+
+
+@bp.route('/api/fotos/upload', methods=['POST'])
+def api_enviar_foto():
+    ano = request.form.get('ano', '').strip()
+    obra = request.form.get('obra', '').strip()
+    arquivo = request.files.get('foto')
+    if not ano or not obra or not arquivo:
+        return jsonify({'error': 'Dados incompletos'}), 400
+    filename = secure_filename(arquivo.filename)
+    try:
+        destino = _safe_join(FOTOS_DIR, ano, obra)
+        os.makedirs(destino, exist_ok=True)
+    except ValueError:
+        return jsonify({'error': 'Caminho inválido'}), 400
+    caminho = os.path.join(destino, filename)
+    arquivo.save(caminho)
     return jsonify({'ok': True})


### PR DESCRIPTION
## Summary
- expose API to list, upload and serve photo files from configurable FOTOS_DIR
- show photos in expandable list and allow capturing/uploading images from camera
- add dialog to select year and obra before taking pictures
- point photo backend to server projects path and handle JPEG images

## Testing
- `python -m py_compile site/projetista/__init__.py`
- `./gradlew test` (fails: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68a749ba2d1c832fa04c6657b114b248