### PR TITLE
feat: serve cached photo thumbnails

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/fragments/PhotoGalleryDialog.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/fragments/PhotoGalleryDialog.kt
@@ -30,9 +30,10 @@ class PhotoGalleryDialog : DialogFragment() {
 
         val prefs = requireContext().getSharedPreferences("app", 0)
         val ip = prefs.getString("api_ip", "192.168.0.135")
-        val baseUrl = "http://$ip:5000/projetista/api/fotos/raw"
+        val thumbUrl = "http://$ip:5000/projetista/api/fotos/thumb"
+        val rawUrl = "http://$ip:5000/projetista/api/fotos/raw"
 
-        recycler.adapter = GalleryAdapter(dir, files, baseUrl) { url ->
+        recycler.adapter = GalleryAdapter(dir, files, thumbUrl, rawUrl) { url ->
             ImageViewerDialog.newInstance(url).show(parentFragmentManager, "viewer")
         }
     }
@@ -40,7 +41,8 @@ class PhotoGalleryDialog : DialogFragment() {
     private class GalleryAdapter(
         private val baseDir: String,
         private val files: List<String>,
-        private val baseUrl: String,
+        private val thumbBaseUrl: String,
+        private val rawBaseUrl: String,
         private val onClick: (String) -> Unit
     ) : RecyclerView.Adapter<GalleryAdapter.VH>() {
 
@@ -56,10 +58,11 @@ class PhotoGalleryDialog : DialogFragment() {
             val file = files[position]
             val path = "$baseDir/AS BUILT/FOTOS/$file"
             val encoded = Uri.encode(path).replace("%2F", "/")
-            val url = "$baseUrl/$encoded"
+            val thumbUrl = "$thumbBaseUrl/$encoded"
+            val rawUrl = "$rawBaseUrl/$encoded"
             val size = holder.image.resources.displayMetrics.widthPixels / 3
-            ImageLoader.loadThumbnail(holder.image, url, size, size)
-            holder.image.setOnClickListener { onClick(url) }
+            ImageLoader.loadThumbnail(holder.image, thumbUrl, size, size)
+            holder.image.setOnClickListener { onClick(rawUrl) }
         }
 
         override fun getItemCount() = files.size

--- a/AppEstoque/app/src/main/java/com/example/apestoque/util/ImageLoader.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/util/ImageLoader.kt
@@ -19,7 +19,6 @@ object ImageLoader {
         Glide.with(iv.context)
             .load(uri)
             .apply(listOptions)
-            .override(targetW, targetH)
             .centerCrop()
             .thumbnail(0.25f)
             .into(iv)

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,12 @@
+# Projetista API
+
+This module exposes endpoints for working with project photos.
+
+## GET /api/fotos/raw/<path>
+Returns the original image file located under `FOTOS_DIR`.
+
+## GET /api/fotos/thumb/<path>
+Generates (on first request) and returns a cached thumbnail of the image with
+maximum dimension 300px. Thumbnails are stored under `_thumb_cache` inside
+`FOTOS_DIR` and reused on subsequent requests. Use this endpoint when
+requesting images for galleries or previews.


### PR DESCRIPTION
## Summary
- add `/api/fotos/thumb/<path>` endpoint that generates and caches 300px thumbnails
- load thumbnail images from new endpoint in Android gallery and keep full-size link for viewer
- simplify `ImageLoader.loadThumbnail` to rely on server-sized images
- document photo API endpoints

## Testing
- `pytest`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a771be301c832f9702f7337f31f116