### PR TITLE
Add in-memory cache for project photo listing

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/FotoNode.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/FotoNode.kt
@@ -2,5 +2,6 @@ package com.example.apestoque.data
 
 data class FotoNode(
     val name: String,
-    val children: List<FotoNode>? = null
+    val path: String? = null,
+    val children: List<FotoNode>? = null,
 )

--- a/AppEstoque/app/src/main/java/com/example/apestoque/fragments/CameraFragment.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/fragments/CameraFragment.kt
@@ -123,10 +123,9 @@ class CameraFragment : Fragment() {
                 )
                 listView.setAdapter(adapter)
                 listView.setOnChildClickListener { _, _, groupPosition, childPosition, _ ->
-                    val ano = fotoTree[groupPosition]
-                    val obra = ano.children?.getOrNull(childPosition)
+                    val obra = fotoTree[groupPosition].children?.getOrNull(childPosition)
                     if (obra != null) {
-                        showPhotoChooser(ano.name, obra)
+                        showPhotoChooser(obra)
                     }
                     true
                 }
@@ -136,10 +135,10 @@ class CameraFragment : Fragment() {
         }
     }
 
-    private fun showPhotoChooser(ano: String, obra: FotoNode) {
-        val arquivos = obra.children?.map { it.name } ?: emptyList()
+    private fun showPhotoChooser(obra: FotoNode) {
+        val arquivos = obra.children?.mapNotNull { it.path } ?: emptyList()
         if (arquivos.isEmpty()) return
-        PhotoGalleryDialog.newInstance(ano, obra.name, ArrayList(arquivos))
+        PhotoGalleryDialog.newInstance(ArrayList(arquivos))
             .show(parentFragmentManager, "gallery")
     }
 }

--- a/AppEstoque/app/src/main/java/com/example/apestoque/fragments/PhotoGalleryDialog.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/fragments/PhotoGalleryDialog.kt
@@ -23,7 +23,6 @@ class PhotoGalleryDialog : DialogFragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        val dir = requireArguments().getString(ARG_DIR)!!
         val files = requireArguments().getStringArrayList(ARG_FILES)!!
         val recycler = view.findViewById<RecyclerView>(R.id.rvGallery)
         recycler.layoutManager = GridLayoutManager(context, 3)
@@ -33,13 +32,12 @@ class PhotoGalleryDialog : DialogFragment() {
         val thumbUrl = "http://$ip:5000/projetista/api/fotos/thumb"
         val rawUrl = "http://$ip:5000/projetista/api/fotos/raw"
 
-        recycler.adapter = GalleryAdapter(dir, files, thumbUrl, rawUrl) { url ->
+        recycler.adapter = GalleryAdapter(files, thumbUrl, rawUrl) { url ->
             ImageViewerDialog.newInstance(url).show(parentFragmentManager, "viewer")
         }
     }
 
     private class GalleryAdapter(
-        private val baseDir: String,
         private val files: List<String>,
         private val thumbBaseUrl: String,
         private val rawBaseUrl: String,
@@ -55,8 +53,7 @@ class PhotoGalleryDialog : DialogFragment() {
         }
 
         override fun onBindViewHolder(holder: VH, position: Int) {
-            val file = files[position]
-            val path = "$baseDir/AS BUILT/FOTOS/$file"
+            val path = files[position]
             val encoded = Uri.encode(path).replace("%2F", "/")
             val thumbUrl = "$thumbBaseUrl/$encoded"
             val rawUrl = "$rawBaseUrl/$encoded"
@@ -68,14 +65,11 @@ class PhotoGalleryDialog : DialogFragment() {
     }
 
     companion object {
-        private const val ARG_DIR = "dir"
         private const val ARG_FILES = "files"
 
-        fun newInstance(ano: String, obra: String, arquivos: ArrayList<String>): PhotoGalleryDialog {
-            val dir = "$ano/$obra"
+        fun newInstance(arquivos: ArrayList<String>): PhotoGalleryDialog {
             return PhotoGalleryDialog().apply {
                 arguments = Bundle().apply {
-                    putString(ARG_DIR, dir)
                     putStringArrayList(ARG_FILES, arquivos)
                 }
             }

--- a/site/README.md
+++ b/site/README.md
@@ -2,6 +2,12 @@
 
 This module exposes endpoints for working with project photos.
 
+## GET /api/fotos
+Returns a tree of available years, works and photo files found under
+`FOTOS_DIR`. Each node has a `name` and optional `children`. File nodes also
+include a `path` relative to `FOTOS_DIR`, which can be used with the thumbnail
+or raw-photo endpoints.
+
 ## GET /api/fotos/raw/<path>
 Returns the original image file located under `FOTOS_DIR`.
 

--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -14,6 +14,8 @@ from datetime import datetime
 from werkzeug.utils import secure_filename
 import urllib.parse
 from PIL import Image
+import time
+import logging
 
 bp = Blueprint('projetista', __name__)
 
@@ -40,6 +42,21 @@ os.makedirs(FOTOS_DIR, exist_ok=True)
 # Diretório onde miniaturas geradas são armazenadas para cache
 THUMB_CACHE_DIR = os.path.join(FOTOS_DIR, "_thumb_cache")
 os.makedirs(THUMB_CACHE_DIR, exist_ok=True)
+
+# Tempo (em segundos) para expiração automática do cache de fotos
+FOTOS_CACHE_TTL = int(os.environ.get("FOTOS_CACHE_TTL", "300"))
+
+# Estrutura simples para cache em memória das árvores de fotos
+_fotos_cache = {"data": None, "timestamp": 0.0, "dir_mtime": 0.0}
+
+logger = logging.getLogger(__name__)
+
+
+def _invalidate_fotos_cache() -> None:
+    """Limpa o cache de fotos, forçando reconstrução futura."""
+    _fotos_cache["data"] = None
+    _fotos_cache["timestamp"] = 0
+    _fotos_cache["dir_mtime"] = 0
 
 # Subpastas que devem ser criadas para cada obra
 SUBPASTAS_OBRA = [
@@ -686,21 +703,30 @@ def _build_asbuilt_tree(base: str) -> list:
         obra_path = "/".join(partes[1:-2])
 
         arquivos = [
-            f for f in sorted(files) if f.lower().endswith(extensoes)
+            {
+                'name': f,
+                'path': f"{ano}/{obra_path}/AS BUILT/FOTOS/{f}",
+            }
+            for f in sorted(files)
+            if f.lower().endswith(extensoes)
         ]
         if not arquivos:
             continue
 
         ano_dict = dados.setdefault(ano, {})
-        ano_dict[obra_path] = [{'name': f} for f in arquivos]
+        ano_dict[obra_path] = arquivos
 
     # Converte dicionário em lista no formato esperado pela API
     arvore = []
     for ano in sorted(dados.keys()):
         obras = []
         for obra in sorted(dados[ano].keys()):
-            obras.append({'name': obra, 'children': dados[ano][obra]})
-        arvore.append({'name': ano, 'children': obras})
+            obras.append({
+                'name': obra,
+                'path': f"{ano}/{obra}",
+                'children': dados[ano][obra],
+            })
+        arvore.append({'name': ano, 'path': ano, 'children': obras})
 
     return arvore
 
@@ -708,7 +734,26 @@ def _build_asbuilt_tree(base: str) -> list:
 @bp.route('/api/fotos')
 def api_listar_fotos():
     """Lista apenas as fotos encontradas em pastas ``AS BUILT/FOTOS``."""
-    return jsonify(_build_asbuilt_tree(FOTOS_DIR))
+    now = time.time()
+    try:
+        dir_mtime = os.path.getmtime(FOTOS_DIR)
+    except OSError:
+        dir_mtime = 0
+
+    cached = (
+        _fotos_cache["data"] is not None
+        and (now - _fotos_cache["timestamp"]) < FOTOS_CACHE_TTL
+        and _fotos_cache["dir_mtime"] == dir_mtime
+    )
+
+    if cached:
+        logger.info("api_listar_fotos cache hit")
+        return jsonify(_fotos_cache["data"])
+
+    logger.info("api_listar_fotos cache miss")
+    data = _build_asbuilt_tree(FOTOS_DIR)
+    _fotos_cache.update({"data": data, "timestamp": now, "dir_mtime": dir_mtime})
+    return jsonify(data)
 
 
 @bp.route('/api/fotos/thumb/<path:filepath>')
@@ -763,4 +808,6 @@ def api_enviar_foto():
         return jsonify({'error': 'Caminho inválido'}), 400
     caminho = os.path.join(destino, filename)
     arquivo.save(caminho)
+    _invalidate_fotos_cache()
+    logger.info("foto upload; cache invalidated")
     return jsonify({'ok': True})


### PR DESCRIPTION
## Summary
- cache AS BUILT photo tree in memory with TTL and directory mtime tracking
- log cache hits/misses and invalidate cache after uploads
- include relative file paths in photo tree and update Android preview to use them

## Testing
- `python -m pytest`
- `cd AppEstoque && ./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a77bc5da8c832f86816ca4bb124481