### PR TITLE
Add swipeable camera sheet and directory-based year selection

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/fragments/CameraFragment.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/fragments/CameraFragment.kt
@@ -5,15 +5,18 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.EditText
+import android.widget.AutoCompleteTextView
 import android.widget.ExpandableListView
+import android.widget.ArrayAdapter
 import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.example.apestoque.R
 import com.example.apestoque.data.FotoNode
 import com.example.apestoque.data.NetworkModule
 import com.google.android.material.floatingactionbutton.FloatingActionButton
+import android.widget.FrameLayout
 import java.util.ArrayList
 import kotlinx.coroutines.launch
 import java.io.File
@@ -30,6 +33,7 @@ class CameraFragment : Fragment() {
 
     private lateinit var listView: ExpandableListView
     private lateinit var btnCamera: FloatingActionButton
+    private lateinit var bottomSheetBehavior: BottomSheetBehavior<FrameLayout>
 
     private var currentPhoto: File? = null
     private var anoSelecionado: String = ""
@@ -51,6 +55,9 @@ class CameraFragment : Fragment() {
         val view = inflater.inflate(R.layout.fragment_camera, container, false)
         listView = view.findViewById(R.id.fotoList)
         btnCamera = view.findViewById(R.id.btnCamera)
+        val bottomSheet: FrameLayout = view.findViewById(R.id.bottomSheet)
+        bottomSheetBehavior = BottomSheetBehavior.from(bottomSheet)
+        bottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
 
         btnCamera.setOnClickListener { showInputDialog() }
 
@@ -61,8 +68,19 @@ class CameraFragment : Fragment() {
 
     private fun showInputDialog() {
         val dialogView = layoutInflater.inflate(R.layout.dialog_save_photo, null)
-        val edtAno = dialogView.findViewById<EditText>(R.id.edtAno)
-        val edtObra = dialogView.findViewById<EditText>(R.id.edtObra)
+        val edtAno = dialogView.findViewById<AutoCompleteTextView>(R.id.edtAno)
+        val edtObra = dialogView.findViewById<AutoCompleteTextView>(R.id.edtObra)
+
+        val anos = fotoTree.map { it.name }
+        val anoAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_dropdown_item_1line, anos)
+        edtAno.setAdapter(anoAdapter)
+        edtAno.setOnItemClickListener { parent, _, position, _ ->
+            anoSelecionado = parent.getItemAtPosition(position) as String
+            val obras = fotoTree.firstOrNull { it.name == anoSelecionado }?.children?.map { it.name } ?: emptyList()
+            val obraAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_dropdown_item_1line, obras)
+            edtObra.setAdapter(obraAdapter)
+        }
+
         AlertDialog.Builder(requireContext())
             .setTitle("Salvar foto")
             .setView(dialogView)

--- a/AppEstoque/app/src/main/res/layout/dialog_save_photo.xml
+++ b/AppEstoque/app/src/main/res/layout/dialog_save_photo.xml
@@ -5,13 +5,13 @@
     android:orientation="vertical"
     android:padding="16dp">
 
-    <EditText
+    <AutoCompleteTextView
         android:id="@+id/edtAno"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="Ano" />
 
-    <EditText
+    <AutoCompleteTextView
         android:id="@+id/edtObra"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/AppEstoque/app/src/main/res/layout/fragment_camera.xml
+++ b/AppEstoque/app/src/main/res/layout/fragment_camera.xml
@@ -1,13 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ExpandableListView
-        android:id="@+id/fotoList"
+    <FrameLayout
+        android:id="@+id/bottomSheet"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:layout_gravity="bottom"
+        android:background="@android:color/white"
+        app:layout_behavior="@string/bottom_sheet_behavior"
+        app:behavior_peekHeight="120dp">
+
+        <ExpandableListView
+            android:id="@+id/fotoList"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </FrameLayout>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/btnCamera"
@@ -17,4 +27,4 @@
         android:layout_margin="16dp"
         app:srcCompat="@android:drawable/ic_menu_camera" />
 
-</FrameLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
## Summary
- add bottom sheet to the camera tab so users can swipe it up or down
- allow selecting predefined years and works when saving a photo using data from the server

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68addb3e8fbc832fbe70e0ba686b436f