### PR TITLE
Add swipeable camera sheet and directory-based year selection

### DIFF
--- a/AppEstoque/app/src/main/res/layout/dialog_save_photo.xml
+++ b/AppEstoque/app/src/main/res/layout/dialog_save_photo.xml
@@ -5,13 +5,13 @@
     android:orientation="vertical"
     android:padding="16dp">
 
-    <EditText
+    <AutoCompleteTextView
         android:id="@+id/edtAno"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="Ano" />
 
-    <EditText
+    <AutoCompleteTextView
         android:id="@+id/edtObra"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/AppEstoque/app/src/main/res/layout/fragment_camera.xml
+++ b/AppEstoque/app/src/main/res/layout/fragment_camera.xml
@@ -1,13 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ExpandableListView
-        android:id="@+id/fotoList"
+    <FrameLayout
+        android:id="@+id/bottomSheet"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:layout_gravity="bottom"
+        android:background="@android:color/white"
+        app:layout_behavior="@string/bottom_sheet_behavior"
+        app:behavior_peekHeight="120dp">
+
+        <ExpandableListView
+            android:id="@+id/fotoList"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </FrameLayout>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/btnCamera"
@@ -17,4 +27,4 @@
         android:layout_margin="16dp"
         app:srcCompat="@android:drawable/ic_menu_camera" />
 
-</FrameLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
## Summary
- add bottom sheet to the camera tab so users can swipe it up or down
- allow selecting predefined years and works when saving a photo using data from the server
- enable taking multiple photos before uploading them to the server

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68addb3e8fbc832fbe70e0ba686b436f