### PR TITLE
Ensure all works are listed when saving photos

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/fragments/PhotoGalleryDialog.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/fragments/PhotoGalleryDialog.kt
@@ -54,7 +54,7 @@ class PhotoGalleryDialog : DialogFragment() {
 
         override fun onBindViewHolder(holder: VH, position: Int) {
             val file = files[position]
-            val path = "$baseDir/AS BUILT/FOTOS/$file"
+            val path = "$baseDir/$file"
             val encoded = Uri.encode(path).replace("%2F", "/")
             val url = "$baseUrl/$encoded"
             val size = holder.image.resources.displayMetrics.widthPixels / 3

--- a/AppEstoque/app/src/main/res/layout/dialog_save_photo.xml
+++ b/AppEstoque/app/src/main/res/layout/dialog_save_photo.xml
@@ -5,13 +5,13 @@
     android:orientation="vertical"
     android:padding="16dp">
 
-    <EditText
+    <AutoCompleteTextView
         android:id="@+id/edtAno"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="Ano" />
 
-    <EditText
+    <AutoCompleteTextView
         android:id="@+id/edtObra"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/AppEstoque/app/src/main/res/layout/fragment_camera.xml
+++ b/AppEstoque/app/src/main/res/layout/fragment_camera.xml
@@ -1,13 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ExpandableListView
-        android:id="@+id/fotoList"
+    <FrameLayout
+        android:id="@+id/bottomSheet"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:layout_gravity="bottom"
+        android:background="@android:color/white"
+        app:layout_behavior="@string/bottom_sheet_behavior"
+        app:behavior_peekHeight="120dp">
+
+        <ExpandableListView
+            android:id="@+id/fotoList"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </FrameLayout>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/btnCamera"
@@ -17,4 +27,4 @@
         android:layout_margin="16dp"
         app:srcCompat="@android:drawable/ic_menu_camera" />
 
-</FrameLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
## Summary
- Traverse server photo tree to expose every `AS BUILT/FOTOS` directory, even empty subfolders
- Simplify upload endpoint to accept the full selected path
- Load gallery images using the complete folder path

## Testing
- `python -m py_compile site/projetista/__init__.py`
- `sh gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68addb3e8fbc832fbe70e0ba686b436f