### PR TITLE
Ensure all works are listed when saving photos

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/MainActivity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/MainActivity.kt
@@ -73,9 +73,19 @@ class MainActivity : AppCompatActivity() {
 
         // Pull to refresh
         swipe.setOnRefreshListener {
-            pager.adapter?.notifyItemChanged(pager.currentItem)
+            if (pager.currentItem != 6) {
+                pager.adapter?.notifyItemChanged(pager.currentItem)
+            }
             swipe.isRefreshing = false
         }
+
+        pager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                swipe.isEnabled = position != 6
+            }
+        })
+
+        swipe.isEnabled = pager.currentItem != 6
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/AppEstoque/app/src/main/java/com/example/apestoque/fragments/CameraFragment.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/fragments/CameraFragment.kt
@@ -1,35 +1,44 @@
 package com.example.apestoque.fragments
 
+import android.Manifest
 import android.app.AlertDialog
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.EditText
+import android.view.WindowManager
+import android.widget.ArrayAdapter
+import android.widget.AutoCompleteTextView
 import android.widget.ExpandableListView
+import android.widget.FrameLayout
+import android.widget.SimpleExpandableListAdapter
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import com.example.apestoque.R
 import com.example.apestoque.data.FotoNode
 import com.example.apestoque.data.NetworkModule
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.floatingactionbutton.FloatingActionButton
-import java.util.ArrayList
-import kotlinx.coroutines.launch
 import java.io.File
 import java.text.SimpleDateFormat
+import java.util.ArrayList
 import java.util.Date
 import java.util.Locale
+import kotlinx.coroutines.launch
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
-import android.widget.SimpleExpandableListAdapter
 
 class CameraFragment : Fragment() {
 
     private lateinit var listView: ExpandableListView
     private lateinit var btnCamera: FloatingActionButton
+    private lateinit var bottomSheetBehavior: BottomSheetBehavior<FrameLayout>
 
     private var currentPhoto: File? = null
     private var anoSelecionado: String = ""
@@ -37,9 +46,25 @@ class CameraFragment : Fragment() {
 
     private var fotoTree: List<FotoNode> = emptyList()
 
-    private val takePicture = registerForActivityResult(androidx.activity.result.contract.ActivityResultContracts.TakePicture()) { success ->
+    private val capturedPhotos = mutableListOf<File>()
+
+    private val takePicture = registerForActivityResult(ActivityResultContracts.TakePicture()) { success ->
         if (success && currentPhoto != null) {
-            uploadPhoto(currentPhoto!!, anoSelecionado, obraSelecionada)
+            capturedPhotos.add(currentPhoto!!)
+            promptAnotherPhoto()
+        } else if (capturedPhotos.isNotEmpty()) {
+            uploadAllPhotos()
+        }
+    }
+
+    private val requestCameraPermission = registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+        if (granted) {
+            launchCamera()
+        } else {
+            AlertDialog.Builder(requireContext())
+                .setMessage("Permissão da câmera negada")
+                .setPositiveButton("OK", null)
+                .show()
         }
     }
 
@@ -51,6 +76,9 @@ class CameraFragment : Fragment() {
         val view = inflater.inflate(R.layout.fragment_camera, container, false)
         listView = view.findViewById(R.id.fotoList)
         btnCamera = view.findViewById(R.id.btnCamera)
+        val bottomSheet: FrameLayout = view.findViewById(R.id.bottomSheet)
+        bottomSheetBehavior = BottomSheetBehavior.from(bottomSheet)
+        bottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
 
         btnCamera.setOnClickListener { showInputDialog() }
 
@@ -61,21 +89,56 @@ class CameraFragment : Fragment() {
 
     private fun showInputDialog() {
         val dialogView = layoutInflater.inflate(R.layout.dialog_save_photo, null)
-        val edtAno = dialogView.findViewById<EditText>(R.id.edtAno)
-        val edtObra = dialogView.findViewById<EditText>(R.id.edtObra)
-        AlertDialog.Builder(requireContext())
+        val edtAno = dialogView.findViewById<AutoCompleteTextView>(R.id.edtAno)
+        val edtObra = dialogView.findViewById<AutoCompleteTextView>(R.id.edtObra)
+
+        val anos = fotoTree.map { it.name }
+        val anoAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_dropdown_item_1line, anos)
+        edtAno.setAdapter(anoAdapter)
+        edtAno.threshold = 0
+        edtAno.setOnClickListener { edtAno.showDropDown() }
+
+        edtObra.threshold = 0
+        edtObra.setOnClickListener { edtObra.showDropDown() }
+
+        edtAno.setOnItemClickListener { parent, _, position, _ ->
+            anoSelecionado = parent.getItemAtPosition(position) as String
+            val obras = fotoTree.firstOrNull { it.name == anoSelecionado }?.children?.map { it.name } ?: emptyList()
+            val obraAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_dropdown_item_1line, obras)
+            edtObra.setAdapter(obraAdapter)
+        }
+
+        val dialog = AlertDialog.Builder(requireContext())
             .setTitle("Salvar foto")
             .setView(dialogView)
             .setPositiveButton("OK") { _, _ ->
                 anoSelecionado = edtAno.text.toString()
                 obraSelecionada = edtObra.text.toString()
+                capturedPhotos.clear()
                 openCamera()
             }
             .setNegativeButton("Cancelar", null)
-            .show()
+            .create()
+
+        dialog.setOnShowListener {
+            dialog.window?.setLayout(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+            )
+            dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+        }
+        dialog.show()
     }
 
     private fun openCamera() {
+        if (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED) {
+            launchCamera()
+        } else {
+            requestCameraPermission.launch(Manifest.permission.CAMERA)
+        }
+    }
+
+    private fun launchCamera() {
         val context = requireContext()
         val photoDir = context.getExternalFilesDir(null) ?: return
         val timeStamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
@@ -85,19 +148,32 @@ class CameraFragment : Fragment() {
         takePicture.launch(uri)
     }
 
-    private fun uploadPhoto(file: File, ano: String, obra: String) {
+    private fun promptAnotherPhoto() {
+        AlertDialog.Builder(requireContext())
+            .setMessage("Tirar outra foto?")
+            .setPositiveButton("Sim") { _, _ -> openCamera() }
+            .setNegativeButton("Não") { _, _ -> uploadAllPhotos() }
+            .setCancelable(false)
+            .show()
+    }
+
+    private fun uploadAllPhotos() {
         val api = NetworkModule.api(requireContext())
+        val photos = capturedPhotos.toList()
+        capturedPhotos.clear()
         viewLifecycleOwner.lifecycleScope.launch {
-            try {
-                val anoBody = ano.toRequestBody("text/plain".toMediaType())
-                val obraBody = obra.toRequestBody("text/plain".toMediaType())
-                val reqFile = file.asRequestBody("image/jpeg".toMediaType())
-                val part = MultipartBody.Part.createFormData("foto", file.name, reqFile)
-                api.enviarFoto(anoBody, obraBody, part)
-                loadPhotos()
-            } catch (e: Exception) {
-                e.printStackTrace()
+            for (file in photos) {
+                try {
+                    val anoBody = anoSelecionado.toRequestBody("text/plain".toMediaType())
+                    val obraBody = obraSelecionada.toRequestBody("text/plain".toMediaType())
+                    val reqFile = file.asRequestBody("image/jpeg".toMediaType())
+                    val part = MultipartBody.Part.createFormData("foto", file.name, reqFile)
+                    api.enviarFoto(anoBody, obraBody, part)
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                }
             }
+            loadPhotos()
         }
     }
 
@@ -106,10 +182,18 @@ class CameraFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             try {
                 fotoTree = api.listarFotos()
-                val groupData = fotoTree.map { mapOf("NAME" to it.name) }
-                val childData = fotoTree.map { ano ->
-                    ano.children?.map { mapOf("NAME" to it.name) } ?: emptyList()
+
+                val groupData = ArrayList<Map<String, String>>()
+                val childData = ArrayList<List<Map<String, String>>>()
+                for (ano in fotoTree) {
+                    groupData.add(hashMapOf("NAME" to ano.name))
+                    val children = ArrayList<Map<String, String>>()
+                    ano.children?.forEach { child ->
+                        children.add(hashMapOf("NAME" to child.name))
+                    }
+                    childData.add(children)
                 }
+
                 val adapter = SimpleExpandableListAdapter(
                     requireContext(),
                     groupData,
@@ -122,6 +206,9 @@ class CameraFragment : Fragment() {
                     intArrayOf(android.R.id.text1)
                 )
                 listView.setAdapter(adapter)
+                for (i in 0 until adapter.groupCount) {
+                    listView.expandGroup(i)
+                }
                 listView.setOnChildClickListener { _, _, groupPosition, childPosition, _ ->
                     val ano = fotoTree[groupPosition]
                     val obra = ano.children?.getOrNull(childPosition)

--- a/AppEstoque/app/src/main/java/com/example/apestoque/fragments/PhotoGalleryDialog.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/fragments/PhotoGalleryDialog.kt
@@ -54,7 +54,7 @@ class PhotoGalleryDialog : DialogFragment() {
 
         override fun onBindViewHolder(holder: VH, position: Int) {
             val file = files[position]
-            val path = "$baseDir/AS BUILT/FOTOS/$file"
+            val path = "$baseDir/$file"
             val encoded = Uri.encode(path).replace("%2F", "/")
             val url = "$baseUrl/$encoded"
             val size = holder.image.resources.displayMetrics.widthPixels / 3

--- a/AppEstoque/app/src/main/res/layout/dialog_save_photo.xml
+++ b/AppEstoque/app/src/main/res/layout/dialog_save_photo.xml
@@ -1,19 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:padding="16dp">
+    android:layout_height="wrap_content">
 
-    <EditText
-        android:id="@+id/edtAno"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="Ano" />
+        android:orientation="vertical"
+        android:padding="16dp">
 
-    <EditText
-        android:id="@+id/edtObra"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="Obra" />
-</LinearLayout>
+        <AutoCompleteTextView
+            android:id="@+id/edtAno"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Ano" />
+
+        <AutoCompleteTextView
+            android:id="@+id/edtObra"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Obra" />
+    </LinearLayout>
+</ScrollView>

--- a/AppEstoque/app/src/main/res/layout/fragment_camera.xml
+++ b/AppEstoque/app/src/main/res/layout/fragment_camera.xml
@@ -1,13 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ExpandableListView
-        android:id="@+id/fotoList"
+    <FrameLayout
+        android:id="@+id/bottomSheet"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:background="@android:color/white"
+        app:layout_behavior="@string/bottom_sheet_behavior"
+        app:behavior_peekHeight="120dp">
+
+        <ExpandableListView
+            android:id="@+id/fotoList"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </FrameLayout>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/btnCamera"
@@ -17,4 +27,4 @@
         android:layout_margin="16dp"
         app:srcCompat="@android:drawable/ic_menu_camera" />
 
-</FrameLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -661,35 +661,34 @@ def _safe_join(root: str, *paths: str) -> str:
 
 
 def _build_asbuilt_tree(base: str) -> list:
-    """Percorre todo ``base`` e lista fotos em pastas ``AS BUILT/FOTOS``."""
+    """Percorre ``base`` e lista pastas ``AS BUILT/FOTOS`` e suas subpastas."""
     extensoes = (".jpg", ".jpeg", ".png")
     dados = {}
+    alvo = os.path.join("AS BUILT", "FOTOS").upper()
 
-    # Procura por qualquer pasta que termine com "AS BUILT/FOTOS"
     for root, _dirs, files in os.walk(base):
-        if not root.upper().endswith(os.path.join("AS BUILT", "FOTOS").upper()):
+        if alvo not in root.upper():
             continue
 
         rel = os.path.relpath(root, base)
         partes = rel.split(os.sep)
         if len(partes) < 3:
-            # precisa ter pelo menos ano/obra/AS BUILT/FOTOS
+            continue
+
+        try:
+            idx = [p.upper() for p in partes].index('AS BUILT')
+        except ValueError:
             continue
 
         ano = partes[0]
-        # Caminho relativo da obra até antes de "AS BUILT"
-        obra_path = "/".join(partes[1:-2])
+        obra_partes = partes[1:idx] + partes[idx + 2:]
+        obra_path = "/".join(obra_partes)
 
-        arquivos = [
-            f for f in sorted(files) if f.lower().endswith(extensoes)
-        ]
-        if not arquivos:
-            continue
+        arquivos = [f for f in sorted(files) if f.lower().endswith(extensoes)]
 
         ano_dict = dados.setdefault(ano, {})
         ano_dict[obra_path] = [{'name': f} for f in arquivos]
 
-    # Converte dicionário em lista no formato esperado pela API
     arvore = []
     for ano in sorted(dados.keys()):
         obras = []
@@ -702,7 +701,7 @@ def _build_asbuilt_tree(base: str) -> list:
 
 @bp.route('/api/fotos')
 def api_listar_fotos():
-    """Lista apenas as fotos encontradas em pastas ``AS BUILT/FOTOS``."""
+    """Lista pastas de fotos, incluindo subpastas vazias."""
     return jsonify(_build_asbuilt_tree(FOTOS_DIR))
 
 
@@ -727,7 +726,7 @@ def api_enviar_foto():
         return jsonify({'error': 'Dados incompletos'}), 400
     filename = secure_filename(arquivo.filename)
     try:
-        destino = _safe_join(FOTOS_DIR, ano, *obra.split('/'), 'AS BUILT', 'FOTOS')
+        destino = _safe_join(FOTOS_DIR, ano, *obra.split('/'))
         os.makedirs(destino, exist_ok=True)
     except ValueError:
         return jsonify({'error': 'Caminho inválido'}), 400


### PR DESCRIPTION
## Summary
- Traverse server photo tree to expose every `AS BUILT/FOTOS` directory, even empty subfolders
- Simplify upload endpoint to accept the full selected path
- Load gallery images using the complete folder path
- Expand the save-photo dialog to full width and resize with the keyboard for better usability
- Disable pull-to-refresh on the camera tab so the swipe gesture is inactive while taking photos
- Fit the camera tab's bottom sheet to its content so the works list no longer leaves extra blank space
- Populate the camera photo list from mutable data and auto-expand groups so saved works appear
- Strip `AS BUILT/FOTOS` segments while traversing server directories so nested works are enumerated correctly

## Testing
- `python -m py_compile site/projetista/__init__.py`
- `sh gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68addb3e8fbc832fbe70e0ba686b436f