### PR TITLE
feat: allow deleting stock requests

### DIFF
--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -240,6 +240,17 @@ def verificar_estoque():
     return render_template('verificar_estoque.html', solicitacoes=solicitacoes)
 
 
+@bp.post('/verificar_estoque/<int:sol_id>/delete')
+@login_required
+def deletar_estoque_solicitacao(sol_id: int):
+    """Remove uma solicitação de verificação de estoque."""
+    sol = EstoqueSolicitacao.query.get_or_404(sol_id)
+    db.session.delete(sol)
+    db.session.commit()
+    flash('Solicitação removida', 'success')
+    return redirect(url_for('projetista.verificar_estoque'))
+
+
 @bp.route('/subpastas', methods=['GET', 'POST'])
 @login_required
 def criar_subpastas():

--- a/site/projetista/templates/verificar_estoque.html
+++ b/site/projetista/templates/verificar_estoque.html
@@ -20,22 +20,28 @@
 </form>
 
 {% for sol in solicitacoes %}
-  <h3 class="mt-4">Solicitação {{ sol.id }}</h3>
-  <table class="table">
-    <thead>
-      <tr><th>Referência</th><th>Quantidade</th><th>Verificado</th><th>Faltante</th></tr>
-    </thead>
-    <tbody>
-    {% for it in sol.itens %}
-      <tr>
-        <td>{{ it.referencia }}</td>
-        <td>{{ it.quantidade }}</td>
-        <td>{{ 'Sim' if it.verificado else 'Não' }}</td>
-        <td>{{ it.faltante }}</td>
-      </tr>
-    {% endfor %}
-    </tbody>
-  </table>
+  <div class="card mb-4 shadow-sm">
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <span>Solicitação {{ sol.id }}</span>
+      <form method="post" action="{{ url_for('projetista.deletar_estoque_solicitacao', sol_id=sol.id) }}" class="mb-0" onsubmit="return confirm('Apagar esta solicitação?');">
+        <button type="submit" class="btn btn-sm btn-danger">
+          <i class="bi bi-trash"></i> Apagar
+        </button>
+      </form>
+    </div>
+    <div class="card-body">
+      <div class="d-flex flex-wrap gap-2">
+        {% for it in sol.itens %}
+        <div class="card card-body p-2" style="min-width: 160px;">
+          <div class="fw-bold">{{ it.referencia }}</div>
+          <small>Qtd: {{ it.quantidade }}</small>
+          <small>Verificado: {{ 'Sim' if it.verificado else 'Não' }}</small>
+          <small>Faltante: {{ it.faltante }}</small>
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
 {% endfor %}
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- enable deleting stock verification requests
- show verification requests in compact card widgets

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae07006438832fb768f880907f2006