### PR TITLE
feat: manage and inspect stock requests

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/adapter/InspecaoSolicitacaoAdapter.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/adapter/InspecaoSolicitacaoAdapter.kt
@@ -1,0 +1,42 @@
+package com.example.apestoque.adapter
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.example.apestoque.R
+import com.example.apestoque.data.InspecaoSolicitacao
+
+class InspecaoSolicitacaoAdapter(
+    private val onClick: (InspecaoSolicitacao) -> Unit,
+) : RecyclerView.Adapter<InspecaoSolicitacaoAdapter.VH>() {
+    private val itens = mutableListOf<InspecaoSolicitacao>()
+
+    fun submitList(lista: List<InspecaoSolicitacao>) {
+        itens.clear()
+        itens.addAll(lista)
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_inspecao_solicitacao, parent, false)
+        return VH(view)
+    }
+
+    override fun getItemCount(): Int = itens.size
+
+    override fun onBindViewHolder(holder: VH, position: Int) {
+        val sol = itens[position]
+        holder.titulo.text = "Solicitação ${sol.id}"
+        holder.qtd.text = "${sol.itens.size} itens"
+        holder.itemView.setOnClickListener { onClick(sol) }
+    }
+
+    class VH(view: View) : RecyclerView.ViewHolder(view) {
+        val titulo: TextView = view.findViewById(R.id.tvTitulo)
+        val qtd: TextView = view.findViewById(R.id.tvQtd)
+    }
+}
+

--- a/AppEstoque/app/src/main/java/com/example/apestoque/fragments/InspecionarFragment.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/fragments/InspecionarFragment.kt
@@ -4,54 +4,65 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import android.widget.Button
 import com.example.apestoque.R
 import com.example.apestoque.adapter.InspecaoAdapter
-import com.example.apestoque.data.NetworkModule
-import com.example.apestoque.data.SolicitacaoRepository
+import com.example.apestoque.adapter.InspecaoSolicitacaoAdapter
 import com.example.apestoque.data.InspecaoResultadoItem
 import com.example.apestoque.data.InspecaoResultadoRequest
+import com.example.apestoque.data.NetworkModule
+import com.example.apestoque.data.SolicitacaoRepository
 import kotlinx.coroutines.launch
 
 class InspecionarFragment : Fragment() {
     private var solicitacaoId: Int? = null
-    private lateinit var adapter: InspecaoAdapter
+    private lateinit var listaAdapter: InspecaoSolicitacaoAdapter
+    private lateinit var itensAdapter: InspecaoAdapter
     private val repo by lazy { SolicitacaoRepository(NetworkModule.api(requireContext())) }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View? {
         return inflater.inflate(R.layout.fragment_inspecionar, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val recycler = view.findViewById<RecyclerView>(R.id.recyclerInspecao)
-        adapter = InspecaoAdapter()
-        recycler.layoutManager = LinearLayoutManager(requireContext())
-        recycler.adapter = adapter
 
+        val recyclerSolic = view.findViewById<RecyclerView>(R.id.recyclerSolicitacoes)
+        val recyclerItens = view.findViewById<RecyclerView>(R.id.recyclerInspecao)
         val btn = view.findViewById<Button>(R.id.btnEnviar)
+
+        listaAdapter = InspecaoSolicitacaoAdapter { sol ->
+            solicitacaoId = sol.id
+            itensAdapter.submitList(sol.itens.map { it.copy() })
+            recyclerSolic.visibility = View.GONE
+            recyclerItens.visibility = View.VISIBLE
+            btn.visibility = View.VISIBLE
+        }
+        recyclerSolic.layoutManager = LinearLayoutManager(requireContext())
+        recyclerSolic.adapter = listaAdapter
+
+        itensAdapter = InspecaoAdapter()
+        recyclerItens.layoutManager = LinearLayoutManager(requireContext())
+        recyclerItens.adapter = itensAdapter
 
         viewLifecycleOwner.lifecycleScope.launch {
             repo.fetchInspecoes()
                 .onSuccess { lista ->
-                    val sol = lista.firstOrNull()
-                    if (sol != null) {
-                        solicitacaoId = sol.id
-                        adapter.submitList(sol.itens)
-                    }
+                    listaAdapter.submitList(lista)
                 }
         }
 
         btn.setOnClickListener {
             val id = solicitacaoId ?: return@setOnClickListener
-            val itens = adapter.getItens().map {
+            val itens = itensAdapter.getItens().map {
                 InspecaoResultadoItem(
                     id = it.id,
                     verificado = it.verificado,
@@ -60,7 +71,16 @@ class InspecionarFragment : Fragment() {
             }
             viewLifecycleOwner.lifecycleScope.launch {
                 repo.enviarResultadoInspecao(id, InspecaoResultadoRequest(itens))
+                    .onSuccess {
+                        recyclerSolic.visibility = View.VISIBLE
+                        recyclerItens.visibility = View.GONE
+                        btn.visibility = View.GONE
+                        solicitacaoId = null
+                        repo.fetchInspecoes()
+                            .onSuccess { lista -> listaAdapter.submitList(lista) }
+                    }
             }
         }
     }
 }
+

--- a/AppEstoque/app/src/main/res/layout/fragment_inspecionar.xml
+++ b/AppEstoque/app/src/main/res/layout/fragment_inspecionar.xml
@@ -5,14 +5,22 @@
     android:layout_height="match_parent">
 
     <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recyclerInspecao"
+        android:id="@+id/recyclerSolicitacoes"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"/>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerInspecao"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:visibility="gone"/>
 
     <Button
         android:id="@+id/btnEnviar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Enviar" />
+        android:text="Enviar"
+        android:visibility="gone" />
 </LinearLayout>

--- a/AppEstoque/app/src/main/res/layout/item_inspecao_solicitacao.xml
+++ b/AppEstoque/app/src/main/res/layout/item_inspecao_solicitacao.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    app:cardCornerRadius="12dp"
+    app:cardElevation="4dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/tvTitulo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="16sp"
+            android:textColor="#000" />
+
+        <TextView
+            android:id="@+id/tvQtd"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textSize="12sp"
+            android:textColor="#666" />
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>
+

--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -240,6 +240,17 @@ def verificar_estoque():
     return render_template('verificar_estoque.html', solicitacoes=solicitacoes)
 
 
+@bp.post('/verificar_estoque/<int:sol_id>/delete')
+@login_required
+def deletar_estoque_solicitacao(sol_id: int):
+    """Remove uma solicitação de verificação de estoque."""
+    sol = EstoqueSolicitacao.query.get_or_404(sol_id)
+    db.session.delete(sol)
+    db.session.commit()
+    flash('Solicitação removida', 'success')
+    return redirect(url_for('projetista.verificar_estoque'))
+
+
 @bp.route('/subpastas', methods=['GET', 'POST'])
 @login_required
 def criar_subpastas():

--- a/site/projetista/templates/verificar_estoque.html
+++ b/site/projetista/templates/verificar_estoque.html
@@ -20,22 +20,28 @@
 </form>
 
 {% for sol in solicitacoes %}
-  <h3 class="mt-4">Solicitação {{ sol.id }}</h3>
-  <table class="table">
-    <thead>
-      <tr><th>Referência</th><th>Quantidade</th><th>Verificado</th><th>Faltante</th></tr>
-    </thead>
-    <tbody>
-    {% for it in sol.itens %}
-      <tr>
-        <td>{{ it.referencia }}</td>
-        <td>{{ it.quantidade }}</td>
-        <td>{{ 'Sim' if it.verificado else 'Não' }}</td>
-        <td>{{ it.faltante }}</td>
-      </tr>
-    {% endfor %}
-    </tbody>
-  </table>
+  <div class="card mb-4 shadow-sm">
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <span>Solicitação {{ sol.id }}</span>
+      <form method="post" action="{{ url_for('projetista.deletar_estoque_solicitacao', sol_id=sol.id) }}" class="mb-0" onsubmit="return confirm('Apagar esta solicitação?');">
+        <button type="submit" class="btn btn-sm btn-danger">
+          <i class="bi bi-trash"></i> Apagar
+        </button>
+      </form>
+    </div>
+    <div class="card-body">
+      <div class="d-flex flex-wrap gap-2">
+        {% for it in sol.itens %}
+        <div class="card card-body p-2" style="min-width: 160px;">
+          <div class="fw-bold">{{ it.referencia }}</div>
+          <small>Qtd: {{ it.quantidade }}</small>
+          <small>Verificado: {{ 'Sim' if it.verificado else 'Não' }}</small>
+          <small>Faltante: {{ it.faltante }}</small>
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
 {% endfor %}
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- enable deleting stock verification requests
- show verification requests in compact card widgets
- list and inspect stock requests in AppEstoque with checkbox checklist

## Testing
- `pytest`
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ae07006438832fb768f880907f2006