### PR TITLE
Enable PDF generation for specific checklist files

### DIFF
--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -472,22 +472,16 @@ def checklist_list():
     return render_template('checklist.html')
 
 
-@bp.route('/checklist/pdf')
+@bp.route('/checklist/pdf/<path:filename>')
 @login_required
-def checklist_pdf():
-    """Gera um PDF com base no checklist JSON mais recente."""
-    arquivos = []
-    for raiz, _dirs, files in os.walk(CHECKLIST_DIR):
-        for name in files:
-            if name.endswith('.json'):
-                arquivos.append(os.path.join(raiz, name))
-
-    if not arquivos:
-        flash('Nenhum checklist disponível.', 'warning')
+def checklist_pdf(filename):
+    """Gera um PDF com base no checklist JSON informado."""
+    caminho = os.path.join(CHECKLIST_DIR, filename)
+    if not os.path.isfile(caminho):
+        flash('Arquivo não encontrado.', 'danger')
         return redirect(url_for('projetista.checklist_list'))
 
-    arquivo_recente = max(arquivos, key=os.path.getmtime)
-    with open(arquivo_recente, encoding='utf-8') as f:
+    with open(caminho, encoding='utf-8') as f:
         dados = json.load(f)
 
     pdf = FPDF()

--- a/site/projetista/templates/checklist_view.html
+++ b/site/projetista/templates/checklist_view.html
@@ -11,6 +11,8 @@
 <p><a href="{{ url_for('projetista.checklist_diff', filename=filename) }}">Comparar com revisão anterior</a></p>
 {% endif %}
 
+<p><a href="{{ url_for('projetista.checklist_pdf', filename=filename) }}">Gerar PDF</a></p>
+
 <table class="table table-striped">
   <thead>
     <tr>

--- a/site/templates/checklist.html
+++ b/site/templates/checklist.html
@@ -35,7 +35,7 @@ pre{background:#111;padding:10px;overflow:auto;}
 <body>
 <div style="padding:10px;">
 <button onclick="window.location.href='{{ url_for('projetista.index') }}'">Início</button>
-<button onclick="window.location.href='{{ url_for('projetista.checklist_pdf') }}'">Gerar PDF</button>
+<button onclick="generatePDF()">Gerar PDF</button>
 </div>
 <div id="container">
 <div class="column" id="foldersCol">
@@ -77,6 +77,16 @@ pre{background:#111;padding:10px;overflow:auto;}
 let folders=[], files=[], currentFolder='', currentFolderLabel='', currentFileName='', currentFileData=null;
 let filters={text:'',status:'',papel:''};
 let paginationState={};
+
+function generatePDF(){
+    if(!currentFileName){
+        alert('Selecione um arquivo primeiro');
+        return;
+    }
+    const path = encodeURIComponent(currentFolder) + '/' + encodeURIComponent(currentFileName);
+    const url = "{{ url_for('projetista.checklist_pdf', filename='') }}" + path;
+    window.location.href = url;
+}
 
 function updatePath(){
     const base=currentFolderLabel||currentFolder;


### PR DESCRIPTION
## Summary
- Load checklist JSON directly via `/checklist/pdf/<filename>` instead of newest file
- Wire "Gerar PDF" actions to pass the selected filename
- Add PDF link on individual checklist view pages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af4ee55658832fae17926119af03ce