### PR TITLE
Use fpdf2 with Unicode fonts for checklist PDFs

### DIFF
--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -13,6 +13,8 @@ import os
 from datetime import datetime
 from werkzeug.utils import secure_filename
 import urllib.parse
+# PDF generation uses the fpdf2 package (pip install fpdf2) for Unicode support.
+# Ensure that the TrueType font "DejaVuSans.ttf" is placed alongside this file.
 from fpdf import FPDF
 import re
 LOGO_PATH = os.path.join(os.path.dirname(__file__), 'static', 'evomax_logo.png')

--- a/site/requirements.txt
+++ b/site/requirements.txt
@@ -3,4 +3,4 @@ Flask-SQLAlchemy>=3.0.0
 openpyxl
 pytz
 Flask-Login
-fpdf
+fpdf2


### PR DESCRIPTION
## Summary
- document fpdf2 requirement and DejaVuSans.ttf for Unicode PDF generation
- depend on fpdf2 instead of fpdf

## Testing
- ⚠️ `pip install fpdf2` (network proxy prevented download)
- ✅ `python -m py_compile site/projetista/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1f3903748832f9352728a10866044