### PR TITLE
PDF: Inserção de faixas extras (Materiais, Oficina, Pré-Montagem, Barramento, Cablagem, IQM, IQE, Testes, Expedição)

### DIFF
--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -716,15 +716,61 @@ def checklist_pdf(filename):
             pdf.add_page()
             _header_row()
 
+    def _section_row(title: str):
+        h = _row_height(title)
+        _maybe_page_break(h)
+        pdf.set_fill_color(*header_fill_rgb)
+        total_w = col_w_item + col_w_resp * len(responsaveis)
+        pdf.rect(left_margin, pdf.get_y(), total_w, h, 'F')
+        pdf.set_xy(left_margin + cell_pad, pdf.get_y() + 1)
+        pdf.set_font(base_font, 'B', 10)
+        pdf.cell(total_w - 2 * cell_pad, line_h - 2, title, border=0)
+        pdf.ln(h)
+        pdf.set_font(base_font, '', 10)
+
     # desenha cabeçalho inicial
     _header_row()
 
+    import unicodedata
+
+    def _norm(s: str) -> str:
+        s = (s or "").strip()
+        s = ''.join(c for c in unicodedata.normalize('NFD', s) if unicodedata.category(c) != 'Mn')
+        s = s.upper().replace('—', ' ').replace('–', ' ').replace('-', ' ')
+        return ' '.join(s.split())
+
     # ---------- Tabela ----------
+    sections_to_insert = [
+        ("1.1", "INVOLUCRO CAIXA",               "Materiais"),
+        ("2.1", "PORTA",                         "OFICINA"),
+        ("3.1", "COMPONENTE",                    "PRÉ-MONTAGEM - 01"),
+        ("4.1", "BARRAMENTO",                    "BARRAMENTO"),
+        ("5.1", "CABLAGEM QD SOBREPOR EMBUTIR",  "CABLAGEM - 01"),
+        ("6.1", "COMPONENTES FIXACAO DIRETA",    "PRÉ-MONTAGEM - 02"),
+        ("6.3", "CABLAGEM AUTOPORTANTE",         "CABLAGEM - 02"),
+        ("",    "TORQUE PARAFUSOS DOS COMPONENTE","IQM - Inspeção de Qualidade Mecânica"),
+        ("",    "CONTINUIDADE PONTO A PONTO FORCA","IQE - Inspeção de Qualidade Elétrica"),
+        ("",    "RESPONSAVEL",                    "TESTES - DADOS"),
+        ("",    "COMUNICADO A TRANSPORTADORA",    "EXPEDIÇÃO 01"),
+        ("",    "LIMPEZA",                         "EXPEDIÇÃO 02"),
+    ]
+    inserted = set()
     zebra = False
     for g in grupos:
         codigo = g["codigo"] or ""
         item = g["item"] or dash_char
         base_item = f"{codigo} - {item}" if codigo else item
+        item_norm = _norm(item)
+
+        for cod_alvo, substr_item, titulo in sections_to_insert:
+            key = (cod_alvo, substr_item, titulo)
+            if key in inserted:
+                continue
+            if (cod_alvo and codigo.strip() == cod_alvo and substr_item in item_norm) or \
+               (not cod_alvo and substr_item in item_norm):
+                _section_row(titulo)
+                inserted.add(key)
+
         subitens = g["subitens"] or [{"subitem": "", "respostas": {}}]
 
         for idx, sub in enumerate(subitens):
@@ -782,88 +828,88 @@ def checklist_pdf(filename):
 
 
 
-    @bp.route('/checklist/<path:filename>')
-    @login_required
-    def checklist_view(filename):
-        caminho = os.path.join(CHECKLIST_DIR, filename)
-        if not os.path.isfile(caminho):
-            flash('Arquivo não encontrado.', 'danger')
-            return redirect(url_for('projetista.checklist_list'))
-        with open(caminho, encoding='utf-8') as f:
-            dados = json.load(f)
-        # verifica se existe revisão anterior para comparação
-        obra = dados.get('obra', 'Desconhecida') or 'Desconhecida'
-        safe_obra = "".join(c for c in obra if c.isalnum() or c in ('-','_')) or 'obra'
-        todos = [n for n in os.listdir(CHECKLIST_DIR)
-                if n.endswith('.json') and n.startswith(f"checklist_{safe_obra}_")]
-        todos.sort()
-        try:
-            idx = todos.index(filename)
-            prev_filename = todos[idx - 1] if idx > 0 else None
-        except ValueError:
-            prev_filename = None
-        return render_template(
-            'checklist_view.html', filename=filename, dados=dados, prev_filename=prev_filename
-        )
+@bp.route('/checklist/<path:filename>')
+@login_required
+def checklist_view(filename):
+    caminho = os.path.join(CHECKLIST_DIR, filename)
+    if not os.path.isfile(caminho):
+        flash('Arquivo não encontrado.', 'danger')
+        return redirect(url_for('projetista.checklist_list'))
+    with open(caminho, encoding='utf-8') as f:
+        dados = json.load(f)
+    # verifica se existe revisão anterior para comparação
+    obra = dados.get('obra', 'Desconhecida') or 'Desconhecida'
+    safe_obra = "".join(c for c in obra if c.isalnum() or c in ('-','_')) or 'obra'
+    todos = [n for n in os.listdir(CHECKLIST_DIR)
+            if n.endswith('.json') and n.startswith(f"checklist_{safe_obra}_")]
+    todos.sort()
+    try:
+        idx = todos.index(filename)
+        prev_filename = todos[idx - 1] if idx > 0 else None
+    except ValueError:
+        prev_filename = None
+    return render_template(
+        'checklist_view.html', filename=filename, dados=dados, prev_filename=prev_filename
+    )
 
 
-    @bp.route('/checklist/diff/<path:filename>')
-    @login_required
-    def checklist_diff(filename):
-        """Exibe as diferenças entre o checklist selecionado e o anterior."""
-        caminho = os.path.join(CHECKLIST_DIR, filename)
-        if not os.path.isfile(caminho):
-            flash('Arquivo não encontrado.', 'danger')
-            return redirect(url_for('projetista.checklist_list'))
+@bp.route('/checklist/diff/<path:filename>')
+@login_required
+def checklist_diff(filename):
+    """Exibe as diferenças entre o checklist selecionado e o anterior."""
+    caminho = os.path.join(CHECKLIST_DIR, filename)
+    if not os.path.isfile(caminho):
+        flash('Arquivo não encontrado.', 'danger')
+        return redirect(url_for('projetista.checklist_list'))
 
-        with open(caminho, encoding='utf-8') as f:
-            atual = json.load(f)
+    with open(caminho, encoding='utf-8') as f:
+        atual = json.load(f)
 
-        obra = atual.get('obra', 'Desconhecida') or 'Desconhecida'
-        safe_obra = "".join(c for c in obra if c.isalnum() or c in ('-','_')) or 'obra'
+    obra = atual.get('obra', 'Desconhecida') or 'Desconhecida'
+    safe_obra = "".join(c for c in obra if c.isalnum() or c in ('-','_')) or 'obra'
 
-        # Localiza o checklist anterior para a mesma obra
-        todos = [n for n in os.listdir(CHECKLIST_DIR)
-                if n.endswith('.json') and n.startswith(f"checklist_{safe_obra}_")]
-        todos.sort()
-        try:
-            idx = todos.index(filename)
-        except ValueError:
-            idx = -1
+    # Localiza o checklist anterior para a mesma obra
+    todos = [n for n in os.listdir(CHECKLIST_DIR)
+            if n.endswith('.json') and n.startswith(f"checklist_{safe_obra}_")]
+    todos.sort()
+    try:
+        idx = todos.index(filename)
+    except ValueError:
+        idx = -1
 
-        if idx <= 0:
-            flash('Não há checklist anterior para comparação.', 'warning')
-            return redirect(url_for('projetista.checklist_view', filename=filename))
+    if idx <= 0:
+        flash('Não há checklist anterior para comparação.', 'warning')
+        return redirect(url_for('projetista.checklist_view', filename=filename))
 
-        anterior_nome = todos[idx - 1]
-        caminho_ant = os.path.join(CHECKLIST_DIR, anterior_nome)
-        with open(caminho_ant, encoding='utf-8') as f:
-            anterior = json.load(f)
+    anterior_nome = todos[idx - 1]
+    caminho_ant = os.path.join(CHECKLIST_DIR, anterior_nome)
+    with open(caminho_ant, encoding='utf-8') as f:
+        anterior = json.load(f)
 
-        antigos = {i['pergunta']: i.get('resposta', [])
-                for i in anterior.get('itens', [])}
-        novos = {i['pergunta']: i.get('resposta', [])
-                for i in atual.get('itens', [])}
+    antigos = {i['pergunta']: i.get('resposta', [])
+            for i in anterior.get('itens', [])}
+    novos = {i['pergunta']: i.get('resposta', [])
+            for i in atual.get('itens', [])}
 
-        diff = []
-        perguntas = sorted(set(antigos) | set(novos))
-        for pergunta in perguntas:
-            resp_ant = antigos.get(pergunta, [])
-            resp_novo = novos.get(pergunta, [])
-            if resp_ant != resp_novo:
-                diff.append({
-                    'pergunta': pergunta,
-                    'antigo': ', '.join(map(str, resp_ant)),
-                    'novo': ', '.join(map(str, resp_novo))
-                })
+    diff = []
+    perguntas = sorted(set(antigos) | set(novos))
+    for pergunta in perguntas:
+        resp_ant = antigos.get(pergunta, [])
+        resp_novo = novos.get(pergunta, [])
+        if resp_ant != resp_novo:
+            diff.append({
+                'pergunta': pergunta,
+                'antigo': ', '.join(map(str, resp_ant)),
+                'novo': ', '.join(map(str, resp_novo))
+            })
 
-        return render_template(
-            'checklist_diff.html',
-            filename=filename,
-            anterior=anterior_nome,
-            diff=diff,
-            obra=obra,
-        )
+    return render_template(
+        'checklist_diff.html',
+        filename=filename,
+        anterior=anterior_nome,
+        diff=diff,
+        obra=obra,
+    )
 
 
 @bp.route('/solicitacao/<int:id>/delete', methods=['POST'])


### PR DESCRIPTION
## Summary
- add `_section_row` and `_norm` helpers to insert section banners before targeted checklist items
- inject extra sections (Materiais, Oficina, Pré‑Montagem, Barramento, Cablagem, IQM, IQE, Testes, Expedição) in generated PDFs
- split Expedição into "Expedição 01" (Comunicado à transportadora) and "Expedição 02" (Limpeza)
- move checklist and diff routes to module level
- fix section match for "COMPONENTES FIXAÇÃO DIRETA" to properly emit "PRÉ-MONTAGEM - 02"

## Testing
- `python -m py_compile site/projetista/__init__.py`
- `pytest`
- `git push -u origin work` *(fails: repository origin not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b57be94d90832f80d2336795a157e0