### PR TITLE
Reduce checklist PDF font size

### DIFF
--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -647,7 +647,7 @@ def checklist_pdf(filename):
 
     pdf.alias_nb_pages()
     pdf.add_page()
-    pdf.set_font(base_font, size=10)
+    pdf.set_font(base_font, size=5)
 
 
     bullet_char = "•" if base_font == "DejaVu" else "-"
@@ -704,7 +704,7 @@ def checklist_pdf(filename):
         x = left_margin
         y = pdf.get_y()
         pdf.set_fill_color(*header_fill_rgb)
-        pdf.set_font(base_font, 'B', 10)
+        pdf.set_font(base_font, 'B', 5)
         # fundo do cabeçalho
         pdf.rect(x, y, col_w_item, line_h, 'F')
         cur_x = x + col_w_item
@@ -720,7 +720,7 @@ def checklist_pdf(filename):
             pdf.cell(col_w_resp - 2 * cell_pad, line_h - 2, r.title(), border=0, align='C')
             cur_x += col_w_resp
         pdf.ln(line_h)
-        pdf.set_font(base_font, '', 10)
+        pdf.set_font(base_font, '', 5)
 
     def _maybe_page_break(row_h, need_header=True):
         bottom_y = pdf.h - pdf.b_margin
@@ -739,10 +739,10 @@ def checklist_pdf(filename):
         total_w = col_w_item + col_w_resp * len(responsaveis)
         pdf.rect(left_margin, pdf.get_y(), total_w, h, 'F')
         pdf.set_xy(left_margin + cell_pad, pdf.get_y() + 1)
-        pdf.set_font(base_font, 'B', 10)
+        pdf.set_font(base_font, 'B', 5)
         pdf.cell(total_w - 2 * cell_pad, line_h - 2, title, border=0)
         pdf.ln(h)
-        pdf.set_font(base_font, '', 10)
+        pdf.set_font(base_font, '', 5)
         _header_row()
         zebra = False
 


### PR DESCRIPTION
## Summary
- shrink checklist PDF font size from 10 to 5
- update header and section row fonts accordingly

## Testing
- `python -m py_compile site/projetista/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b59fc303f0832fba86573807bdb0b4