### PR TITLE
Fix indentation error in checklist blueprint

### DIFF
--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -654,7 +654,7 @@ def checklist_pdf(filename):
 
 
     # ---------- PDF ----------
-   class ChecklistPDF(FPDF):
+    class ChecklistPDF(FPDF):
         def __init__(self, obra='', ano='', suprimento='', producao='', montadores=None,
                      cidade_estado='', projesta='', data_checklist='', inspetor='',
                      data_geracao='', *args, **kwargs):


### PR DESCRIPTION
## Summary
- fix indentation of `ChecklistPDF` class in `projetista` blueprint

## Testing
- `python -m py_compile site/projetista/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b742d89640832f9dec79853721d6a9