### PR TITLE
Use named response groups in checklist items

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Activity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Activity.kt
@@ -155,7 +155,7 @@
 
 
             findViewById<Button>(R.id.btnConcluirPosto01).setOnClickListener {
-                val respostas = triplets.mapIndexed { index, (cbC, cbNC, cbNA) ->
+                val respostasSelecionadas = triplets.mapIndexed { index, (cbC, cbNC, cbNA) ->
                     val marcados = mutableListOf<String>()
                     if (cbC.isChecked) marcados.add("C")
                     if (cbNC.isChecked) marcados.add("NC")
@@ -168,10 +168,10 @@
                 }
 
                 val itensChecklist = questions.indices.map { i ->
-                    ChecklistItem(i + 1, questions[i], respostas[i])
+                    ChecklistItem(i + 1, questions[i], mapOf("suprimento" to respostasSelecionadas[i]))
                 }
 
-                if (respostas.any { it.contains("NC") }) {
+                if (respostasSelecionadas.any { it.contains("NC") }) {
                     val ano = Calendar.getInstance().get(Calendar.YEAR).toString()
                     val prefs = getSharedPreferences("app", Context.MODE_PRIVATE)
                     val suprimento = prefs.getString("operador_suprimentos", "") ?: ""

--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Parte2Activity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Parte2Activity.kt
@@ -109,7 +109,7 @@ class ChecklistPosto01Parte2Activity : AppCompatActivity() {
 
 
         findViewById<Button>(R.id.btnConcluirPosto01Parte2).setOnClickListener {
-            val respostas = triplets.mapIndexed { index, (cbC, cbNC, cbNA) ->
+            val respostasSelecionadas = triplets.mapIndexed { index, (cbC, cbNC, cbNA) ->
                 val marcados = mutableListOf<String>()
                 if (cbC.isChecked) marcados.add("C")
                 if (cbNC.isChecked) marcados.add("NC")
@@ -122,7 +122,7 @@ class ChecklistPosto01Parte2Activity : AppCompatActivity() {
             }
 
             val itensChecklist = prevItems + questions.indices.map { i ->
-                ChecklistItem(i + 55, questions[i], respostas[i])
+                ChecklistItem(i + 55, questions[i], mapOf("suprimento" to respostasSelecionadas[i]))
             }
 
             val ano = Calendar.getInstance().get(Calendar.YEAR).toString()

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/ChecklistRequest.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/ChecklistRequest.kt
@@ -6,7 +6,7 @@ import com.squareup.moshi.JsonClass
 data class ChecklistItem(
     val numero: Int,
     val pergunta: String,
-    val resposta: List<String>
+    val respostas: Map<String, List<String>>
 )
 
 @JsonClass(generateAdapter = true)

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/JsonNetworkModule.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/JsonNetworkModule.kt
@@ -11,7 +11,7 @@ object JsonNetworkModule {
         val ip = context.getSharedPreferences("app", Context.MODE_PRIVATE)
             .getString("api_ip", "192.168.0.135")
         val moshi = Moshi.Builder()
-            .add(KotlinJsonAdapterFactory())
+            .addLast(KotlinJsonAdapterFactory())
             .build()
         val retrofit = Retrofit.Builder()
             .baseUrl("http://$ip:5000/json_api/")


### PR DESCRIPTION
## Summary
- Replace `resposta` list with `respostas` map in `ChecklistItem`
- Populate `respostas` for each item in Posto 01 activities
- Ensure Moshi uses latest adapters for checklist serialization

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b89672872c832fafc200a9030a0f76