### PR TITLE
Use named response groups in checklist items

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Activity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Activity.kt
@@ -155,7 +155,7 @@
 
 
             findViewById<Button>(R.id.btnConcluirPosto01).setOnClickListener {
-                val respostas = triplets.mapIndexed { index, (cbC, cbNC, cbNA) ->
+                val respostasSelecionadas = triplets.mapIndexed { index, (cbC, cbNC, cbNA) ->
                     val marcados = mutableListOf<String>()
                     if (cbC.isChecked) marcados.add("C")
                     if (cbNC.isChecked) marcados.add("NC")
@@ -168,10 +168,10 @@
                 }
 
                 val itensChecklist = questions.indices.map { i ->
-                    ChecklistItem(i + 1, questions[i], respostas[i])
+                    ChecklistItem(i + 1, questions[i], mapOf("suprimento" to respostasSelecionadas[i]))
                 }
 
-                if (respostas.any { it.contains("NC") }) {
+                if (respostasSelecionadas.any { it.contains("NC") }) {
                     val ano = Calendar.getInstance().get(Calendar.YEAR).toString()
                     val prefs = getSharedPreferences("app", Context.MODE_PRIVATE)
                     val suprimento = prefs.getString("operador_suprimentos", "") ?: ""

--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Parte2Activity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Parte2Activity.kt
@@ -109,7 +109,7 @@ class ChecklistPosto01Parte2Activity : AppCompatActivity() {
 
 
         findViewById<Button>(R.id.btnConcluirPosto01Parte2).setOnClickListener {
-            val respostas = triplets.mapIndexed { index, (cbC, cbNC, cbNA) ->
+            val respostasSelecionadas = triplets.mapIndexed { index, (cbC, cbNC, cbNA) ->
                 val marcados = mutableListOf<String>()
                 if (cbC.isChecked) marcados.add("C")
                 if (cbNC.isChecked) marcados.add("NC")
@@ -122,7 +122,7 @@ class ChecklistPosto01Parte2Activity : AppCompatActivity() {
             }
 
             val itensChecklist = prevItems + questions.indices.map { i ->
-                ChecklistItem(i + 55, questions[i], respostas[i])
+                ChecklistItem(i + 55, questions[i], mapOf("producao" to respostasSelecionadas[i]))
             }
 
             val ano = Calendar.getInstance().get(Calendar.YEAR).toString()

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/ChecklistRequest.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/ChecklistRequest.kt
@@ -6,7 +6,7 @@ import com.squareup.moshi.JsonClass
 data class ChecklistItem(
     val numero: Int,
     val pergunta: String,
-    val resposta: List<String>
+    val respostas: Map<String, List<String>>
 )
 
 @JsonClass(generateAdapter = true)

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/JsonNetworkModule.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/JsonNetworkModule.kt
@@ -11,7 +11,7 @@ object JsonNetworkModule {
         val ip = context.getSharedPreferences("app", Context.MODE_PRIVATE)
             .getString("api_ip", "192.168.0.135")
         val moshi = Moshi.Builder()
-            .add(KotlinJsonAdapterFactory())
+            .addLast(KotlinJsonAdapterFactory())
             .build()
         val retrofit = Retrofit.Builder()
             .baseUrl("http://$ip:5000/json_api/")

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto01Parte2Activity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto01Parte2Activity.kt
@@ -177,7 +177,9 @@ class ChecklistPosto01Parte2Activity : AppCompatActivity() {
                         else -> ""
                     }
                 )
-                obj.put("resposta", resp)
+                val respostas = JSONObject()
+                respostas.put("producao", resp)
+                obj.put("respostas", respostas)
                 itens.put(obj)
             }
             val payload = JSONObject()


### PR DESCRIPTION
## Summary
- Accept respondent names under either accented or unaccented keys when merging checklists
- Read grouped `respostas` for both suprimento and produção to avoid null entries in merged JSON
- Detect production files even if they use the `producao` field

## Testing
- `python -m py_compile site/json_api/merge_checklists.py`
- `python site/json_api/merge_checklists.py site/json_api`
- `./gradlew test` (AppEstoque) *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*
- `./gradlew test` (AppOficina) *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b89672872c832fafc200a9030a0f76