### PR TITLE
Enhance Posto 08 inspector checklist with environment data

### DIFF
--- a/AppOficina/app/src/main/AndroidManifest.xml
+++ b/AppOficina/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
         android:networkSecurityConfig="@xml/network_security_config"

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto08TesteActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto08TesteActivity.kt
@@ -1,13 +1,20 @@
 package com.example.appoficina
 
+import android.Manifest
+import android.app.AlertDialog
 import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Bundle
+import android.text.InputType
+import android.widget.ArrayAdapter
 import android.widget.Button
 import android.widget.CheckBox
 import android.widget.EditText
 import android.widget.LinearLayout
+import android.widget.Spinner
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.OutputStreamWriter
@@ -15,6 +22,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 
 class ChecklistPosto08TesteActivity : AppCompatActivity() {
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_checklist_posto08_teste)
@@ -25,38 +33,101 @@ class ChecklistPosto08TesteActivity : AppCompatActivity() {
 
         val container = findViewById<LinearLayout>(R.id.questions_container)
 
-        // 8.3 - TESTE - DADOS
-        val dadosPerguntas = listOf(
-            "Responsável",
-            "Altitude em relação ao nivel do mar",
-            "Tipo de ambiente",
-            "Temperatura Ambiente",
-            "Humidade relátiva",
-            "Tensão de comando",
-            "Tensão circuito auxiliar",
-            "Tensão circuito de força",
-        )
-        val dadosInputs = mutableListOf<EditText>()
-        dadosPerguntas.forEach { pergunta ->
+        fun addLabel(text: String) {
             val tv = TextView(this)
-            tv.text = pergunta
+            tv.text = text
             container.addView(tv)
-            val et = EditText(this)
-            container.addView(et)
-            dadosInputs.add(et)
         }
+
+        // 8.3 - TESTE - DADOS
+        addLabel("Responsável")
+        val responsavelInput = EditText(this)
+        container.addView(responsavelInput)
+
+        addLabel("Altitude em relação ao nivel do mar")
+        val altitudeInput = EditText(this)
+        altitudeInput.isEnabled = false
+        container.addView(altitudeInput)
+
+        addLabel("Grau de Poluição")
+        val poluicaoSpinner = Spinner(this)
+        val poluicaoOptions = listOf(
+            "Grau de poluição 1: Não ocorre poluição ou somente uma poluição seca não-condutiva. A poluição não tem nenhuma influência.",
+            "Grau de poluição 2: Presença somente de uma poluição não-condutiva, exceto que, ocasionalmente, uma condutividade temporária causada por condensação pode ocorrer.",
+            "Grau de poluição 3: Presença de uma poluição condutiva ou de uma poluição seca não-condutiva, que pode se tornar condutiva devido à condensação.",
+            "Grau de poluição 4: Ocorre uma condutividade contínua devido a presença de pó condutivo, chuva ou outras condições úmidas."
+        )
+        poluicaoSpinner.adapter =
+            ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, poluicaoOptions)
+        container.addView(poluicaoSpinner)
+
+        addLabel("Grau de proteção (IP)")
+        val ipInput = EditText(this)
+        container.addView(ipInput)
+
+        addLabel("Instalação")
+        val instalSpinner = Spinner(this)
+        instalSpinner.adapter = ArrayAdapter(
+            this,
+            android.R.layout.simple_spinner_dropdown_item,
+            listOf("Abrigada", "Ao tempo")
+        )
+        container.addView(instalSpinner)
+
+        addLabel("Aplicação")
+        val aplicSpinner = Spinner(this)
+        aplicSpinner.adapter = ArrayAdapter(
+            this,
+            android.R.layout.simple_spinner_dropdown_item,
+            listOf("Industrial", "Comercial", "Agro", "Residencial", "Data center", "Fotovoltaico")
+        )
+        container.addView(aplicSpinner)
+
+        addLabel("Temperatura Ambiente")
+        val tempInput = EditText(this)
+        tempInput.inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL
+        tempInput.setOnFocusChangeListener { _, hasFocus ->
+            if (hasFocus) {
+                AlertDialog.Builder(this)
+                    .setMessage("preencher com a temperatura do medidor do relogio da produção")
+                    .setPositiveButton("OK", null)
+                    .show()
+            }
+        }
+        container.addView(tempInput)
+
+        addLabel("Humidade relativa")
+        val humidadeInput = EditText(this)
+        humidadeInput.isEnabled = false
+        container.addView(humidadeInput)
+
+        addLabel("Tensão de comando (V)")
+        val tensaoComandoInput = EditText(this)
+        container.addView(tensaoComandoInput)
+
+        addLabel("Tensão circuito auxiliar (V)")
+        val tensaoAuxInput = EditText(this)
+        container.addView(tensaoAuxInput)
+
+        addLabel("Tensão circuito de força (V)")
+        val tensaoForcaInput = EditText(this)
+        container.addView(tensaoForcaInput)
+
+        fetchAmbientData(altitudeInput, humidadeInput)
 
         // 8.4 - TESTE - TENSÃO APLICADA
         data class TensaoRefs(
-            val unidade: EditText,
+            val unidade: Spinner,
             val valor: EditText,
-            val resUnidade: EditText,
+            val resUnidade: Spinner,
             val resValor: EditText,
             val c: CheckBox,
             val nc: CheckBox,
             val na: CheckBox,
         )
 
+        val unidadeOptions = listOf("V", "kV")
+        val resUnidadeOptions = listOf("Ohm", "Mohm", "Gigaohm", "MΩ", "GΩ", "TΩ", "mA")
         val tensaoPerguntas = listOf(
             "4.2 - Comando x Terra",
             "4.3 - Força - Fase A x BC Terra",
@@ -66,27 +137,35 @@ class ChecklistPosto08TesteActivity : AppCompatActivity() {
         )
         val tensaoRefs = mutableListOf<TensaoRefs>()
         tensaoPerguntas.forEach { pergunta ->
-            val tv = TextView(this)
-            tv.text = pergunta
-            container.addView(tv)
+            addLabel(pergunta)
             val row1 = LinearLayout(this)
             row1.orientation = LinearLayout.HORIZONTAL
-            val unidade = EditText(this)
-            unidade.hint = "Unidade"
+            val unidade = Spinner(this)
+            unidade.adapter = ArrayAdapter(
+                this,
+                android.R.layout.simple_spinner_dropdown_item,
+                unidadeOptions
+            )
             val valor = EditText(this)
             valor.hint = "Valor"
             row1.addView(unidade)
             row1.addView(valor)
             container.addView(row1)
+
             val row2 = LinearLayout(this)
             row2.orientation = LinearLayout.HORIZONTAL
-            val resUni = EditText(this)
-            resUni.hint = "Resultado: Unidade"
+            val resUni = Spinner(this)
+            resUni.adapter = ArrayAdapter(
+                this,
+                android.R.layout.simple_spinner_dropdown_item,
+                resUnidadeOptions
+            )
             val resVal = EditText(this)
             resVal.hint = "Resultado: Valor"
             row2.addView(resUni)
             row2.addView(resVal)
             container.addView(row2)
+
             val row3 = LinearLayout(this)
             row3.orientation = LinearLayout.HORIZONTAL
             val c = CheckBox(this)
@@ -101,6 +180,7 @@ class ChecklistPosto08TesteActivity : AppCompatActivity() {
             row3.addView(nc)
             row3.addView(na)
             container.addView(row3)
+
             tensaoRefs.add(TensaoRefs(unidade, valor, resUni, resVal, c, nc, na))
 
             c.setOnCheckedChangeListener { _, isChecked -> if (isChecked) { nc.isChecked = false; na.isChecked = false } }
@@ -121,9 +201,7 @@ class ChecklistPosto08TesteActivity : AppCompatActivity() {
         )
         val configPairs = mutableListOf<Pair<CheckBox, CheckBox>>()
         configPerguntas.forEach { pergunta ->
-            val tv = TextView(this)
-            tv.text = pergunta
-            container.addView(tv)
+            addLabel(pergunta)
             val row = LinearLayout(this)
             row.orientation = LinearLayout.HORIZONTAL
             val c = CheckBox(this)
@@ -151,9 +229,7 @@ class ChecklistPosto08TesteActivity : AppCompatActivity() {
         )
         val funcPairs = mutableListOf<Pair<CheckBox, CheckBox>>()
         funcPerguntas.forEach { pergunta ->
-            val tv = TextView(this)
-            tv.text = pergunta
-            container.addView(tv)
+            addLabel(pergunta)
             val row = LinearLayout(this)
             row.orientation = LinearLayout.HORIZONTAL
             val c = CheckBox(this)
@@ -175,54 +251,55 @@ class ChecklistPosto08TesteActivity : AppCompatActivity() {
             Thread {
                 val itens = JSONArray()
                 var numero = 8301
-                dadosPerguntas.forEachIndexed { idx, pergunta ->
+
+                fun addItem(pergunta: String, respostas: List<String>) {
                     val obj = JSONObject()
                     obj.put("numero", numero++)
                     obj.put("pergunta", pergunta)
                     val arr = JSONArray()
-                    arr.put(dadosInputs[idx].text.toString())
+                    respostas.forEach { arr.put(it) }
                     obj.put("resposta", arr)
                     itens.put(obj)
                 }
+
+                addItem("Responsável", listOf(responsavelInput.text.toString()))
+                addItem("Altitude em relação ao nivel do mar", listOf(altitudeInput.text.toString()))
+                addItem("Grau de Poluição", listOf(poluicaoSpinner.selectedItem.toString()))
+                addItem("Grau de proteção (IP)", listOf(ipInput.text.toString()))
+                addItem("Instalação", listOf(instalSpinner.selectedItem.toString()))
+                addItem("Aplicação", listOf(aplicSpinner.selectedItem.toString()))
+                addItem("Temperatura Ambiente", listOf(tempInput.text.toString()))
+                addItem("Humidade relativa", listOf(humidadeInput.text.toString()))
+                addItem("Tensão de comando", listOf(tensaoComandoInput.text.toString()))
+                addItem("Tensão circuito auxiliar", listOf(tensaoAuxInput.text.toString()))
+                addItem("Tensão circuito de força", listOf(tensaoForcaInput.text.toString()))
+
                 tensaoPerguntas.forEachIndexed { idx, pergunta ->
                     val refs = tensaoRefs[idx]
-                    val obj = JSONObject()
-                    obj.put("numero", numero++)
-                    obj.put("pergunta", pergunta)
-                    val arr = JSONArray()
-                    arr.put(refs.unidade.text.toString())
-                    arr.put(refs.valor.text.toString())
-                    arr.put(refs.resUnidade.text.toString())
-                    arr.put(refs.resValor.text.toString())
-                    arr.put(
-                        when {
-                            refs.c.isChecked -> "C"
-                            refs.nc.isChecked -> "NC"
-                            else -> "NA"
-                        },
+                    addItem(
+                        pergunta,
+                        listOf(
+                            refs.unidade.selectedItem.toString(),
+                            refs.valor.text.toString(),
+                            refs.resUnidade.selectedItem.toString(),
+                            refs.resValor.text.toString(),
+                            when {
+                                refs.c.isChecked -> "C"
+                                refs.nc.isChecked -> "NC"
+                                else -> "NA"
+                            }
+                        )
                     )
-                    obj.put("resposta", arr)
-                    itens.put(obj)
                 }
+
                 configPerguntas.forEachIndexed { idx, pergunta ->
                     val (c, na) = configPairs[idx]
-                    val obj = JSONObject()
-                    obj.put("numero", numero++)
-                    obj.put("pergunta", pergunta)
-                    val arr = JSONArray()
-                    arr.put(if (c.isChecked) "C" else "NA")
-                    obj.put("resposta", arr)
-                    itens.put(obj)
+                    addItem(pergunta, listOf(if (c.isChecked) "C" else "NA"))
                 }
+
                 funcPerguntas.forEachIndexed { idx, pergunta ->
                     val (c, na) = funcPairs[idx]
-                    val obj = JSONObject()
-                    obj.put("numero", numero++)
-                    obj.put("pergunta", pergunta)
-                    val arr = JSONArray()
-                    arr.put(if (c.isChecked) "C" else "NA")
-                    obj.put("resposta", arr)
-                    itens.put(obj)
+                    addItem(pergunta, listOf(if (c.isChecked) "C" else "NA"))
                 }
 
                 val payload = JSONObject()
@@ -233,6 +310,49 @@ class ChecklistPosto08TesteActivity : AppCompatActivity() {
                 enviarChecklist(payload, "/json_api/posto08_teste/update")
             }.start()
             finish()
+        }
+    }
+
+    private fun fetchAmbientData(altitudeView: EditText, humidadeView: EditText) {
+        if (ActivityCompat.checkSelfPermission(
+                this,
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(Manifest.permission.ACCESS_FINE_LOCATION),
+                100
+            )
+            return
+        }
+        val lm = getSystemService(Context.LOCATION_SERVICE) as android.location.LocationManager
+        val loc = lm.getLastKnownLocation(android.location.LocationManager.GPS_PROVIDER)
+            ?: lm.getLastKnownLocation(android.location.LocationManager.NETWORK_PROVIDER)
+        loc?.let {
+            val lat = it.latitude
+            val lon = it.longitude
+            Thread {
+                try {
+                    val altUrl = URL("https://api.open-meteo.com/v1/elevation?latitude=$lat&longitude=$lon")
+                    val altConn = altUrl.openConnection() as HttpURLConnection
+                    val altRes = altConn.inputStream.bufferedReader().use { r -> r.readText() }
+                    val alt = JSONObject(altRes).getJSONArray("elevation").optDouble(0)
+                    altConn.disconnect()
+
+                    val humUrl = URL("https://api.open-meteo.com/v1/forecast?latitude=$lat&longitude=$lon&current=relative_humidity_2m")
+                    val humConn = humUrl.openConnection() as HttpURLConnection
+                    val humRes = humConn.inputStream.bufferedReader().use { r -> r.readText() }
+                    val hum = JSONObject(humRes).getJSONObject("current").optDouble("relative_humidity_2m")
+                    humConn.disconnect()
+
+                    runOnUiThread {
+                        altitudeView.setText(alt.toString())
+                        humidadeView.setText(hum.toString())
+                    }
+                } catch (_: Exception) {
+                }
+            }.start()
         }
     }
 

--- a/site/json_api/POSTO08_TESTE/checklist_TESTE.json
+++ b/site/json_api/POSTO08_TESTE/checklist_TESTE.json
@@ -4,278 +4,37 @@
   "posto08_teste": {
     "inspetor": "muri",
     "itens": [
-      {
-        "numero": 8301,
-        "pergunta": "Responsável",
-        "respostas": {
-          "inspetor": [
-            "tomtom"
-          ]
-        }
-      },
-      {
-        "numero": 8302,
-        "pergunta": "Altitude em relação ao nivel do mar",
-        "respostas": {
-          "inspetor": [
-            "56"
-          ]
-        }
-      },
-      {
-        "numero": 8303,
-        "pergunta": "Tipo de ambiente",
-        "respostas": {
-          "inspetor": [
-            "b9m"
-          ]
-        }
-      },
-      {
-        "numero": 8304,
-        "pergunta": "Temperatura Ambiente",
-        "respostas": {
-          "inspetor": [
-            "67"
-          ]
-        }
-      },
-      {
-        "numero": 8305,
-        "pergunta": "Humidade relatíva",
-        "respostas": {
-          "inspetor": [
-            "88"
-          ]
-        }
-      },
-      {
-        "numero": 8306,
-        "pergunta": "Tensão de comando",
-        "respostas": {
-          "inspetor": [
-            "222"
-          ]
-        }
-      },
-      {
-        "numero": 8307,
-        "pergunta": "Tensão circuito auxiliar",
-        "respostas": {
-          "inspetor": [
-            "23"
-          ]
-        }
-      },
-      {
-        "numero": 8308,
-        "pergunta": "Tensão circuito de força",
-        "respostas": {
-          "inspetor": [
-            "222"
-          ]
-        }
-      },
-      {
-        "numero": 8309,
-        "pergunta": "4.2 - Comando x Terra",
-        "respostas": {
-          "inspetor": [
-            "v",
-            "23",
-            "v",
-            "34",
-            "C"
-          ]
-        }
-      },
-      {
-        "numero": 8310,
-        "pergunta": "4.3 - Força - Fase A x BC Terra",
-        "respostas": {
-          "inspetor": [
-            "45",
-            "u88",
-            "56",
-            "34",
-            "C"
-          ]
-        }
-      },
-      {
-        "numero": 8311,
-        "pergunta": "4.4 - Força - Fase B x AC Terra",
-        "respostas": {
-          "inspetor": [
-            "y",
-            "66",
-            "mm",
-            "76",
-            "C"
-          ]
-        }
-      },
-      {
-        "numero": 8312,
-        "pergunta": "4.5 - Força - Fase C x AB Terra",
-        "respostas": {
-          "inspetor": [
-            "vb",
-            "22",
-            "bv",
-            "67",
-            "C"
-          ]
-        }
-      },
-      {
-        "numero": 8313,
-        "pergunta": "4.6 - Força - Fase ABC x Terra",
-        "respostas": {
-          "inspetor": [
-            "mn",
-            "222",
-            "mn",
-            "55",
-            "C"
-          ]
-        }
-      },
-      {
-        "numero": 8314,
-        "pergunta": "Multimedidores",
-        "respostas": {
-          "inspetor": [
-            "C"
-          ]
-        }
-      },
-      {
-        "numero": 8315,
-        "pergunta": "Controladores",
-        "respostas": {
-          "inspetor": [
-            "C"
-          ]
-        }
-      },
-      {
-        "numero": 8316,
-        "pergunta": "Drives",
-        "respostas": {
-          "inspetor": [
-            "C"
-          ]
-        }
-      },
-      {
-        "numero": 8317,
-        "pergunta": "Monitores",
-        "respostas": {
-          "inspetor": [
-            "C"
-          ]
-        }
-      },
-      {
-        "numero": 8318,
-        "pergunta": "Sensores",
-        "respostas": {
-          "inspetor": [
-            "C"
-          ]
-        }
-      },
-      {
-        "numero": 8319,
-        "pergunta": "IHMs",
-        "respostas": {
-          "inspetor": [
-            "C"
-          ]
-        }
-      },
-      {
-        "numero": 8320,
-        "pergunta": "Timers",
-        "respostas": {
-          "inspetor": [
-            "C"
-          ]
-        }
-      },
-      {
-        "numero": 8321,
-        "pergunta": "Dispositivos de proteção ajustável",
-        "respostas": {
-          "inspetor": [
-            "C"
-          ]
-        }
-      },
-      {
-        "numero": 8322,
-        "pergunta": "Sinalizadores",
-        "respostas": {
-          "inspetor": [
-            "C"
-          ]
-        }
-      },
-      {
-        "numero": 8323,
-        "pergunta": "Status à campo",
-        "respostas": {
-          "inspetor": [
-            "C"
-          ]
-        }
-      },
-      {
-        "numero": 8324,
-        "pergunta": "Leituras",
-        "respostas": {
-          "inspetor": [
-            "C"
-          ]
-        }
-      },
-      {
-        "numero": 8325,
-        "pergunta": "Intertravamentos",
-        "respostas": {
-          "inspetor": [
-            "C"
-          ]
-        }
-      },
-      {
-        "numero": 8326,
-        "pergunta": "Lógica de acionamento",
-        "respostas": {
-          "inspetor": [
-            "C"
-          ]
-        }
-      },
-      {
-        "numero": 8327,
-        "pergunta": "Programa",
-        "respostas": {
-          "inspetor": [
-            "C"
-          ]
-        }
-      },
-      {
-        "numero": 8328,
-        "pergunta": "Tensão das saídas à campo",
-        "respostas": {
-          "inspetor": [
-            "C"
-          ]
-        }
-      }
+      { "numero": 8301, "pergunta": "Responsável", "respostas": { "inspetor": ["tomtom"] } },
+      { "numero": 8302, "pergunta": "Altitude em relação ao nivel do mar", "respostas": { "inspetor": ["56"] } },
+      { "numero": 8303, "pergunta": "Grau de Poluição", "respostas": { "inspetor": ["Grau de poluição 1"] } },
+      { "numero": 8304, "pergunta": "Grau de proteção (IP)", "respostas": { "inspetor": ["IP55"] } },
+      { "numero": 8305, "pergunta": "Instalação", "respostas": { "inspetor": ["Abrigada"] } },
+      { "numero": 8306, "pergunta": "Aplicação", "respostas": { "inspetor": ["Industrial"] } },
+      { "numero": 8307, "pergunta": "Temperatura Ambiente", "respostas": { "inspetor": ["67"] } },
+      { "numero": 8308, "pergunta": "Humidade relativa", "respostas": { "inspetor": ["88"] } },
+      { "numero": 8309, "pergunta": "Tensão de comando", "respostas": { "inspetor": ["222"] } },
+      { "numero": 8310, "pergunta": "Tensão circuito auxiliar", "respostas": { "inspetor": ["23"] } },
+      { "numero": 8311, "pergunta": "Tensão circuito de força", "respostas": { "inspetor": ["222"] } },
+        { "numero": 8312, "pergunta": "4.2 - Comando x Terra", "respostas": { "inspetor": ["V", "23", "Ohm", "34", "C"] } },
+        { "numero": 8313, "pergunta": "4.3 - Força - Fase A x BC Terra", "respostas": { "inspetor": ["V", "45", "Ohm", "56", "C"] } },
+        { "numero": 8314, "pergunta": "4.4 - Força - Fase B x AC Terra", "respostas": { "inspetor": ["V", "66", "Ohm", "76", "C"] } },
+        { "numero": 8315, "pergunta": "4.5 - Força - Fase C x AB Terra", "respostas": { "inspetor": ["V", "22", "Ohm", "67", "C"] } },
+        { "numero": 8316, "pergunta": "4.6 - Força - Fase ABC x Terra", "respostas": { "inspetor": ["V", "222", "Ohm", "55", "C"] } },
+      { "numero": 8317, "pergunta": "Multimedidores", "respostas": { "inspetor": ["C"] } },
+      { "numero": 8318, "pergunta": "Controladores", "respostas": { "inspetor": ["C"] } },
+      { "numero": 8319, "pergunta": "Drives", "respostas": { "inspetor": ["C"] } },
+      { "numero": 8320, "pergunta": "Monitores", "respostas": { "inspetor": ["C"] } },
+      { "numero": 8321, "pergunta": "Sensores", "respostas": { "inspetor": ["C"] } },
+      { "numero": 8322, "pergunta": "IHMs", "respostas": { "inspetor": ["C"] } },
+      { "numero": 8323, "pergunta": "Timers", "respostas": { "inspetor": ["C"] } },
+      { "numero": 8324, "pergunta": "Dispositivos de proteção ajustável", "respostas": { "inspetor": ["C"] } },
+      { "numero": 8325, "pergunta": "Sinalizadores", "respostas": { "inspetor": ["C"] } },
+      { "numero": 8326, "pergunta": "Status à campo", "respostas": { "inspetor": ["C"] } },
+      { "numero": 8327, "pergunta": "Leituras", "respostas": { "inspetor": ["C"] } },
+      { "numero": 8328, "pergunta": "Intertravamentos", "respostas": { "inspetor": ["C"] } },
+      { "numero": 8329, "pergunta": "Lógica de acionamento", "respostas": { "inspetor": ["C"] } },
+      { "numero": 8330, "pergunta": "Programa", "respostas": { "inspetor": ["C"] } },
+      { "numero": 8331, "pergunta": "Tensão das saídas à campo", "respostas": { "inspetor": ["C"] } }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- add fine location permission
- extend Posto 08 Teste checklist with environmental data fields and unit selectors
- update sample checklist JSON to match new questions
- refine unit selections for applied voltage tests

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d62703ec832f885a5359d45501c2