### PR TITLE
Agrupa duplicados por pergunta na limpeza de checklist

### DIFF
--- a/clean_watch_posto02.py
+++ b/clean_watch_posto02.py
@@ -158,32 +158,40 @@ def clean_item(raw_item: Dict[str, Any]) -> Optional[Dict[str, Any]]:
 
 
 def merge_duplicates(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Merge items that have the same ``numero``.
+    """Merge items that have the same ``pergunta``.
 
-    Histories from duplicated questions are concatenated in the order of
-    appearance.  The most recent answer for each function is therefore the
-    last element of the combined history list.
+    Each pergunta acts as the primary identifier.  Histories from duplicated
+    questions are concatenated per função preserving their original order so
+    that the last element of each list remains the most recent resposta.  The
+    returned ``numero`` for each pergunta is the canonical one defined in
+    ``BASE_QUESTIONS`` when available; otherwise the smallest ``numero``
+    encountered for that pergunta is used.
     """
 
-    grouped: Dict[int, Dict[str, Any]] = {}
-    order: List[int] = []
+    grouped: Dict[str, Dict[str, Any]] = {}
+    order: List[str] = []
     for item in items:
-        n = item["numero"]
-        if n not in grouped:
-            grouped[n] = {
-                "numero": n,
-                "pergunta": item["pergunta"],
+        key = item["pergunta"]
+        if key not in grouped:
+            grouped[key] = {
+                "pergunta": key,
+                "numeros": [item["numero"]],
                 "respostas": {f: list(item["respostas"][f]) for f in FUNCS},
             }
-            order.append(n)
+            order.append(key)
         else:
-            g = grouped[n]
+            g = grouped[key]
+            g["numeros"].append(item["numero"])
             for f in FUNCS:
                 g["respostas"][f].extend(item["respostas"][f])
 
     result: List[Dict[str, Any]] = []
-    for n in order:
-        result.append(grouped[n])
+    for key in order:
+        g = grouped[key]
+        nums = g["numeros"]
+        canonical = next((n for n, q in BASE_QUESTIONS.items() if q == key), None)
+        numero = canonical if canonical is not None else min(nums)
+        result.append({"numero": numero, "pergunta": key, "respostas": g["respostas"]})
     return result
 
 


### PR DESCRIPTION
## Summary
- Mescla itens do checklist pela pergunta, preservando histórico de respostas
- Usa número canônico da BASE_QUESTIONS ou o menor número encontrado

## Testing
- `python -m py_compile clean_watch_posto02.py`
- `python clean_watch_posto02.py --once`


------
https://chatgpt.com/codex/tasks/task_e_68bac3e2c030832f89fb945f4b064825