### PR TITLE
Deduplicate checklist responses

### DIFF
--- a/clean_watch_posto02.py
+++ b/clean_watch_posto02.py
@@ -194,6 +194,15 @@ def merge_duplicates(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
     result: List[Dict[str, Any]] = []
     for g in grouped.values():
+        for f in FUNCS:
+            seen: set[str] = set()
+            unique: List[str] = []
+            for resp in reversed(g["respostas"][f]):
+                if resp not in seen:
+                    seen.add(resp)
+                    unique.append(resp)
+            unique.reverse()
+            g["respostas"][f] = unique
         nums = g["numeros"]
         candidates = [n for n, q in BASE_QUESTIONS.items() if q == g["pergunta"]]
         canonical = min(candidates) if candidates else None


### PR DESCRIPTION
## Summary
- remove duplicate answers per function in merge_duplicates
- keep only the latest occurrence of each answer and maintain order

## Testing
- `python -m py_compile clean_watch_posto02.py`
- `python clean_watch_posto02.py --once`


------
https://chatgpt.com/codex/tasks/task_e_68bad47bec18832fb8a3e12ff2db571d