### PR TITLE
Add Revisão tab with network loading

### DIFF
--- a/AppOficina/app/build.gradle.kts
+++ b/AppOficina/app/build.gradle.kts
@@ -42,6 +42,20 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
     implementation(libs.androidx.viewpager2)
+
+    // Networking + JSON
+    implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation("com.squareup.retrofit2:converter-moshi:2.9.0")
+    implementation("com.squareup.okhttp3:logging-interceptor:5.0.0-alpha.11")
+    implementation("com.squareup.moshi:moshi-kotlin:1.15.0")
+
+    // Coroutines
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1")
+
+    // UI helpers
+    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.2.0-alpha01")
+    implementation("androidx.recyclerview:recyclerview:1.3.2")
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/AppOficina/app/src/main/AndroidManifest.xml
+++ b/AppOficina/app/src/main/AndroidManifest.xml
@@ -44,6 +44,7 @@
         <activity android:name=".ChecklistPosto08IqeActivity" android:exported="false" android:screenOrientation="landscape" />
         <activity android:name=".ChecklistPosto08IqmActivity" android:exported="false" android:screenOrientation="landscape" />
         <activity android:name=".ChecklistPosto08TesteActivity" android:exported="false" android:screenOrientation="landscape" />
+        <activity android:name=".RevisaoDetailActivity" android:exported="false" android:screenOrientation="landscape" />
 
     </application>
 

--- a/AppOficina/app/src/main/java/com/example/appoficina/DivergenciaAdapter.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/DivergenciaAdapter.kt
@@ -1,0 +1,32 @@
+package com.example.appoficina
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+
+class DivergenciaAdapter(private val itens: List<Divergencia>) :
+    RecyclerView.Adapter<DivergenciaAdapter.VH>() {
+
+    class VH(view: View) : RecyclerView.ViewHolder(view) {
+        val pergunta: TextView = view.findViewById(R.id.tvPergunta)
+        val sup: TextView = view.findViewById(R.id.tvSup)
+        val prod: TextView = view.findViewById(R.id.tvProd)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
+        val v = LayoutInflater.from(parent.context).inflate(R.layout.item_divergencia, parent, false)
+        return VH(v)
+    }
+
+    override fun getItemCount(): Int = itens.size
+
+    override fun onBindViewHolder(holder: VH, position: Int) {
+        val d = itens[position]
+        holder.pergunta.text = "Item ${d.numero}: ${d.pergunta}"
+        holder.sup.text = "Suprimento: ${d.suprimento?.joinToString() ?: "-"}"
+        holder.prod.text = "Produção: ${d.producao?.joinToString() ?: "-"}"
+    }
+}
+

--- a/AppOficina/app/src/main/java/com/example/appoficina/JsonApiService.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/JsonApiService.kt
@@ -1,0 +1,22 @@
+package com.example.appoficina
+
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import com.squareup.moshi.JsonClass
+
+interface JsonApiService {
+    @GET("revisao")
+    suspend fun listarRevisao(): List<RevisaoChecklist>
+
+    @POST("revisao/reenviar")
+    suspend fun reenviarChecklist(
+        @Body body: ReenvioRequest
+    ) : ChecklistResponse
+}
+
+@JsonClass(generateAdapter = true)
+data class ChecklistResponse(
+    val status: String
+)
+

--- a/AppOficina/app/src/main/java/com/example/appoficina/JsonNetworkModule.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/JsonNetworkModule.kt
@@ -1,0 +1,37 @@
+package com.example.appoficina
+
+import android.content.Context
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+object JsonNetworkModule {
+    fun api(context: Context): JsonApiService {
+        val prefs = context.getSharedPreferences("app", Context.MODE_PRIVATE)
+        val ip = prefs.getString("api_ip", "192.168.0.135")
+
+        val moshi = Moshi.Builder()
+            .addLast(KotlinJsonAdapterFactory())
+            .build()
+
+        val logging = HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BASIC
+        }
+
+        val client = OkHttpClient.Builder()
+            .addInterceptor(logging)
+            .build()
+
+        val retrofit = Retrofit.Builder()
+            .baseUrl("http://$ip:5000/json_api/")
+            .client(client)
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .build()
+
+        return retrofit.create(JsonApiService::class.java)
+    }
+}
+

--- a/AppOficina/app/src/main/java/com/example/appoficina/MainActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/MainActivity.kt
@@ -90,6 +90,7 @@ class MainActivity : AppCompatActivity() {
             Posto05CablagemFragment(),
             Posto06PreMontagemFragment(),
             Posto06Cablagem02Fragment(),
+            RevisaoFragment(),
             SimpleTextFragment.newInstance("POSTO - 09 EXPEDIÇÃO")
         )
         val titles = listOf(
@@ -100,6 +101,7 @@ class MainActivity : AppCompatActivity() {
             "05 - POSTO - 05 CABLAGEM - 01",
             "06 - POSTO - 06 PRÉ-MONTAGEM - 02",
             "06.1 - POSTO - 06 CABLAGEM - 02",
+            "REVISÃO",
             "POSTO - 09 EXPEDIÇÃO"
         )
         val tabKeys = listOf<String?>(
@@ -110,6 +112,7 @@ class MainActivity : AppCompatActivity() {
             "pass_05",
             "pass_06",
             "pass_06_1",
+            null,
             "pass_09"
         )
 

--- a/AppOficina/app/src/main/java/com/example/appoficina/ReenvioRequest.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ReenvioRequest.kt
@@ -1,0 +1,10 @@
+package com.example.appoficina
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class ReenvioRequest(
+    val obra: String,
+    val ano: String
+)
+

--- a/AppOficina/app/src/main/java/com/example/appoficina/Revisao.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/Revisao.kt
@@ -1,0 +1,21 @@
+package com.example.appoficina
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import java.io.Serializable
+
+@JsonClass(generateAdapter = true)
+data class Divergencia(
+    val numero: Int,
+    val pergunta: String,
+    val suprimento: List<String>?,
+    @Json(name = "produção") val producao: List<String>?,
+) : Serializable
+
+@JsonClass(generateAdapter = true)
+data class RevisaoChecklist(
+    val obra: String,
+    val ano: String,
+    val divergencias: List<Divergencia>
+) : Serializable
+

--- a/AppOficina/app/src/main/java/com/example/appoficina/RevisaoAdapter.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/RevisaoAdapter.kt
@@ -1,0 +1,31 @@
+package com.example.appoficina
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+
+class RevisaoAdapter(
+    private val itens: List<RevisaoChecklist>,
+    private val onClick: (RevisaoChecklist) -> Unit
+) : RecyclerView.Adapter<RevisaoAdapter.VH>() {
+
+    class VH(view: View) : RecyclerView.ViewHolder(view) {
+        val tv: TextView = view.findViewById(R.id.tvRevisao)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
+        val v = LayoutInflater.from(parent.context).inflate(R.layout.item_revisao, parent, false)
+        return VH(v)
+    }
+
+    override fun getItemCount(): Int = itens.size
+
+    override fun onBindViewHolder(holder: VH, position: Int) {
+        val item = itens[position]
+        holder.tv.text = "${item.obra} (${item.ano}) - ${item.divergencias.size} divergência(s)"
+        holder.itemView.setOnClickListener { onClick(item) }
+    }
+}
+

--- a/AppOficina/app/src/main/java/com/example/appoficina/RevisaoDetailActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/RevisaoDetailActivity.kt
@@ -1,0 +1,47 @@
+package com.example.appoficina
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class RevisaoDetailActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_revisao_detail)
+
+        val checklist = intent.getSerializableExtra("revisao") as? RevisaoChecklist
+        if (checklist == null) {
+            finish()
+            return
+        }
+
+        findViewById<TextView>(R.id.tvTitulo).text = "${checklist.obra} (${checklist.ano})"
+        val rv = findViewById<RecyclerView>(R.id.rvDivs)
+        rv.adapter = DivergenciaAdapter(checklist.divergencias)
+
+        val btn = findViewById<Button>(R.id.btnReenviar)
+        btn.setOnClickListener {
+            lifecycleScope.launch {
+                try {
+                    withContext(Dispatchers.IO) {
+                        JsonNetworkModule.api(this@RevisaoDetailActivity).reenviarChecklist(
+                            ReenvioRequest(checklist.obra, checklist.ano)
+                        )
+                    }
+                    Toast.makeText(this@RevisaoDetailActivity, "Enviado", Toast.LENGTH_SHORT).show()
+                    finish()
+                } catch (e: Exception) {
+                    Toast.makeText(this@RevisaoDetailActivity, "Erro ao enviar", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+}
+

--- a/AppOficina/app/src/main/java/com/example/appoficina/RevisaoFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/RevisaoFragment.kt
@@ -1,0 +1,66 @@
+package com.example.appoficina
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class RevisaoFragment : Fragment() {
+
+    private lateinit var swipe: SwipeRefreshLayout
+    private lateinit var rv: RecyclerView
+    private lateinit var tvMsg: TextView
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View? = inflater.inflate(R.layout.fragment_revisao, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        swipe = view.findViewById(R.id.swipeRevisao)
+        rv = view.findViewById(R.id.rvRevisao)
+        tvMsg = view.findViewById(R.id.tvMensagemRevisao)
+        swipe.setOnRefreshListener { carregar() }
+        carregar()
+    }
+
+    private fun carregar() {
+        swipe.isRefreshing = true
+        lifecycleScope.launch {
+            try {
+                val lista = withContext(Dispatchers.IO) { JsonNetworkModule.api(requireContext()).listarRevisao() }
+                if (lista.isEmpty()) {
+                    tvMsg.text = "Nenhuma divergência."
+                    tvMsg.visibility = View.VISIBLE
+                    rv.visibility = View.GONE
+                } else {
+                    tvMsg.visibility = View.GONE
+                    rv.visibility = View.VISIBLE
+                    rv.adapter = RevisaoAdapter(lista) { selecionado ->
+                        val intent = Intent(requireContext(), RevisaoDetailActivity::class.java)
+                        intent.putExtra("revisao", selecionado)
+                        startActivity(intent)
+                    }
+                }
+            } catch (e: Exception) {
+                tvMsg.text = "Erro ao carregar"
+                tvMsg.visibility = View.VISIBLE
+                rv.visibility = View.GONE
+            } finally {
+                swipe.isRefreshing = false
+            }
+        }
+    }
+}
+

--- a/AppOficina/app/src/main/res/layout/activity_revisao_detail.xml
+++ b/AppOficina/app/src/main/res/layout/activity_revisao_detail.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/tvTitulo"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:textSize="18sp"
+        android:textStyle="bold"/>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvDivs"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
+
+    <Button
+        android:id="@+id/btnReenviar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Reenviar para Oficina"/>
+
+</LinearLayout>
+

--- a/AppOficina/app/src/main/res/layout/fragment_revisao.xml
+++ b/AppOficina/app/src/main/res/layout/fragment_revisao.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/swipeRevisao"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/tvMensagemRevisao"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="Carregando..."/>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rvRevisao"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone"
+            android:padding="16dp"/>
+
+    </FrameLayout>
+
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+

--- a/AppOficina/app/src/main/res/layout/item_divergencia.xml
+++ b/AppOficina/app/src/main/res/layout/item_divergencia.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/tvPergunta"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"/>
+
+    <TextView
+        android:id="@+id/tvSup"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+
+    <TextView
+        android:id="@+id/tvProd"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+
+</LinearLayout>
+

--- a/AppOficina/app/src/main/res/layout/item_revisao.xml
+++ b/AppOficina/app/src/main/res/layout/item_revisao.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/tvRevisao"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="16dp"
+    android:textSize="16sp" />
+


### PR DESCRIPTION
## Summary
- add Revisão fragment and detail screen to AppOficina
- wire new tab in MainActivity and register in manifest
- include Retrofit, Moshi, coroutines and UI dependencies

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bebf3a4088832fb1d0bd23f0b93130