### PR TITLE
Fix Revisão tab loading in AppEstoque

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/fragments/RevisaoFragment.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/fragments/RevisaoFragment.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.example.apestoque.R
@@ -35,13 +36,14 @@ class RevisaoFragment : Fragment() {
         swipe = view.findViewById(R.id.swipeRevisao)
         rv = view.findViewById(R.id.rvRevisao)
         tvMsg = view.findViewById(R.id.tvMensagemRevisao)
+        rv.layoutManager = LinearLayoutManager(requireContext())
         swipe.setOnRefreshListener { carregar() }
         carregar()
     }
 
     private fun carregar() {
         swipe.isRefreshing = true
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             try {
                 val lista = withContext(Dispatchers.IO) { JsonNetworkModule.api(requireContext()).listarRevisao() }
                 if (lista.isEmpty()) {
@@ -58,7 +60,7 @@ class RevisaoFragment : Fragment() {
                     }
                 }
             } catch (e: Exception) {
-                tvMsg.text = "Erro ao carregar"
+                tvMsg.text = "Erro ao carregar: ${e.localizedMessage}"
                 tvMsg.visibility = View.VISIBLE
                 rv.visibility = View.GONE
             } finally {


### PR DESCRIPTION
## Summary
- set RecyclerView layout manager in Revisão fragment
- launch refresh coroutine with view lifecycle scope and expose error details
- ensure Revisão fragment source terminates cleanly to avoid duplicate activity declarations

## Testing
- `bash gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bec12eed98832fb97fd822f596fde8