### PR TITLE
fix: order force circuit voltage question and adjust PDF title spacing

### DIFF
--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -582,9 +582,6 @@ def checklist_pdf(filename):
     # ---------- Helpers de parsing/agrupamento ----------
     def _natural_key_codigo(pergunta: str):
         # pega "1.10" de "1.10 - CANALETAS: ..." e transforma em [1,10]
-        norm = _norm(pergunta)
-        if norm == "TENSAO CIRCUITO DE FORCA":
-            return [4, 1, 5]
         m = re.match(r"\s*([0-9]+(?:\.[0-9]+)*)\s*-\s*", pergunta or "")
         if not m:
             return [float('inf')]
@@ -972,10 +969,13 @@ def checklist_pdf(filename):
     def _section_row(title: str, responsaveis_atual):
         nonlocal zebra
         h = _row_height(title)
-        _maybe_page_break(h + line_h, need_header=False)
+        extra = line_h  # espaçamento adicional antes do título
+        _maybe_page_break(extra + h + line_h, need_header=False)
+        pdf.ln(extra)
         pdf.set_fill_color(*header_fill_rgb)
-        pdf.rect(left_margin, pdf.get_y(), total_w, h, 'F')
-        pdf.set_xy(left_margin + cell_pad, pdf.get_y() + 1)
+        y0 = pdf.get_y()
+        pdf.rect(left_margin, y0, total_w, h, 'F')
+        pdf.set_xy(left_margin + cell_pad, y0 + 1)
         pdf.set_font(base_font, 'B', 10)
         pdf.cell(total_w - 2 * cell_pad, line_h - 2, title, border=0)
         pdf.ln(h)


### PR DESCRIPTION
## Summary
- remove special-case sorting for `Tensão circuito de força`
- add blank line before section titles in PDF output

## Testing
- `python -m py_compile site/projetista/__init__.py`
- Generated sample checklist PDF and converted to text to confirm blank line preceding a section title


------
https://chatgpt.com/codex/tasks/task_e_68becb4b80a0832f9b23686961331913