### PR TITLE
Suporte a múltiplos números em divergências

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/adapter/DivergenciaAdapter.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/adapter/DivergenciaAdapter.kt
@@ -26,7 +26,7 @@ class DivergenciaAdapter(private val itens: List<Divergencia>) :
 
     override fun onBindViewHolder(holder: VH, position: Int) {
         val d = itens[position]
-        holder.pergunta.text = "Item ${d.numero}: ${d.pergunta}"
+        holder.pergunta.text = "Item ${d.numero.joinToString()}: ${d.pergunta}"
         holder.sup.text = "Suprimento: ${d.suprimento?.joinToString() ?: "-"}"
         holder.prod.text = "Produção: ${d.producao?.joinToString() ?: "-"}"
     }

--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Parte2Activity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Parte2Activity.kt
@@ -136,7 +136,7 @@ class ChecklistPosto01Parte2Activity : AppCompatActivity() {
             
             val itensChecklist = prevItems + triplets.indices.map { i ->
                 ChecklistItem(i + 75, questions[i], mapOf("producao" to respostasSelecionadas[i]))
-
+            }
 
             val ano = Calendar.getInstance().get(Calendar.YEAR).toString()
 

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/IntListAdapter.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/IntListAdapter.kt
@@ -1,0 +1,39 @@
+package com.example.apestoque.data
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.ToJson
+
+class IntListAdapter {
+    @FromJson
+    fun fromJson(reader: JsonReader): List<Int> {
+        return when (reader.peek()) {
+            JsonReader.Token.BEGIN_ARRAY -> {
+                val list = mutableListOf<Int>()
+                reader.beginArray()
+                while (reader.hasNext()) {
+                    list.add(reader.nextInt())
+                }
+                reader.endArray()
+                list
+            }
+            JsonReader.Token.NULL -> {
+                reader.nextNull<Unit>()
+                emptyList()
+            }
+            else -> listOf(reader.nextInt())
+        }
+    }
+
+    @ToJson
+    fun toJson(writer: JsonWriter, value: List<Int>?) {
+        if (value == null) {
+            writer.nullValue()
+            return
+        }
+        writer.beginArray()
+        value.forEach { writer.value(it) }
+        writer.endArray()
+    }
+}

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/JsonNetworkModule.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/JsonNetworkModule.kt
@@ -3,6 +3,7 @@ package com.example.apestoque.data
 import android.content.Context
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import com.example.apestoque.data.IntListAdapter
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 
@@ -11,6 +12,7 @@ object JsonNetworkModule {
         val ip = context.getSharedPreferences("app", Context.MODE_PRIVATE)
             .getString("api_ip", "192.168.0.135")
         val moshi = Moshi.Builder()
+            .add(IntListAdapter())
             .addLast(KotlinJsonAdapterFactory())
             .build()
         val retrofit = Retrofit.Builder()

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/NetworkModule.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/NetworkModule.kt
@@ -3,6 +3,7 @@ package com.example.apestoque.data
 import android.content.Context
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import com.example.apestoque.data.IntListAdapter
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 
@@ -11,6 +12,7 @@ object NetworkModule {
         val ip = context.getSharedPreferences("app", Context.MODE_PRIVATE)
             .getString("api_ip", "192.168.0.135")
         val moshi = Moshi.Builder()
+            .add(IntListAdapter())
             .add(KotlinJsonAdapterFactory())
             .build()
         val retrofit = Retrofit.Builder()

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/Revisao.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/Revisao.kt
@@ -6,7 +6,7 @@ import java.io.Serializable
 
 @JsonClass(generateAdapter = true)
 data class Divergencia(
-    val numero: Int,
+    val numero: List<Int>,
     val pergunta: String,
     val suprimento: List<String>?,
     @Json(name = "produção") val producao: List<String>?,


### PR DESCRIPTION
## Summary
- Aceita listas de números na entidade `Divergencia`
- Exibe múltiplos números com `joinToString` no adapter
- Cria `IntListAdapter` e registra em módulos de rede
- Corrige bloco de mapeamento no `ChecklistPosto01Parte2Activity` que estava sem chave de fechamento

## Testing
- `./gradlew test --stacktrace --console=plain` *(falhou: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68becbd55fa0832fbb4550b99c5cff18