### PR TITLE
Handle inspetor role when formatting checklist PDF

### DIFF
--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -1106,7 +1106,7 @@ def checklist_pdf(filename):
             max_resp_lines = 0
             for role in current_roles:
                 vals = [str(v).strip() for v in sub["respostas"].get(role, []) if str(v).strip()]
-                if role == "resposta" and len(vals) >= 5:
+                if role in ("resposta", "inspetor") and len(vals) >= 5:
                     formatted = (
                         f"1. Tensão aplicada: {vals[0]}, {vals[1]}\n"
                         f"2. Resultado: {vals[2]}, {vals[3]}\n"


### PR DESCRIPTION
## Summary
- Format "inspetor" responses like "resposta" when five values are present so the "Comando x Terra" output includes numbered lines

## Testing
- `pytest`
- Generated `checklist_PRO900.pdf` from `checklist_pdf()` and verified numbered output for "Comando x Terra" under the Inspetor column


------
https://chatgpt.com/codex/tasks/task_e_68c166cd133c832fb0840300a34b9ae3