### PR TITLE
Handle inspetor role when formatting checklist PDF

### DIFF
--- a/site/projetista/__init__.py
+++ b/site/projetista/__init__.py
@@ -937,7 +937,7 @@ def checklist_pdf(filename):
             return usable_w, 0.0, usable_w
         col_w_item = 135.0
         col_w_resp = (usable_w - col_w_item) / count
-        if col_w_resp > 28.0:
+        if count > 1 and col_w_resp > 28.0:
             col_w_resp = 28.0
             col_w_item = usable_w - col_w_resp * count
         elif col_w_resp < 22.0:
@@ -1106,10 +1106,10 @@ def checklist_pdf(filename):
             max_resp_lines = 0
             for role in current_roles:
                 vals = [str(v).strip() for v in sub["respostas"].get(role, []) if str(v).strip()]
-                if role == "resposta" and len(vals) >= 5:
+                if role in ("resposta", "inspetor") and len(vals) >= 5:
                     formatted = (
-                        f"1. Tensão aplicada: {vals[0]}, {vals[1]}\n"
-                        f"2. Resultado: {vals[2]}, {vals[3]}\n"
+                        f"1. Tensão aplicada: {vals[1]} {vals[0]}\n"
+                        f"2. Resultado: {vals[3]} {vals[2]}\n"
                         f"3. Situação: {vals[4]}"
                     )
                 elif len(vals) >= 5:
@@ -1144,7 +1144,7 @@ def checklist_pdf(filename):
             cur_x = x0 + col_w_item
             for val in roles_vals:
                 pdf.set_xy(cur_x + cell_pad, y0 + 1)
-                pdf.multi_cell(col_w_resp - 2 * cell_pad, line_h, val, border=0, align='C')
+                pdf.multi_cell(col_w_resp - 2 * cell_pad, line_h, val, border=0, align='L')
                 cur_x += col_w_resp
                 pdf.set_xy(cur_x, y0)
 


### PR DESCRIPTION
## Summary
- Format "inspetor" and "resposta" tension lines with numeric values before units so PDF shows "44 kV" and "23 TΩ"

## Testing
- `pytest`
- Generated `checklist_PRO900.pdf` and confirmed "Comando x Terra" shows numbered lines with values preceding units

------
https://chatgpt.com/codex/tasks/task_e_68c166cd133c832fb0840300a34b9ae3