### PR TITLE
Include sector name in Posto01 checklist payload

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto01Parte2Activity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto01Parte2Activity.kt
@@ -25,6 +25,10 @@ class ChecklistPosto01Parte2Activity : AppCompatActivity() {
         val obra = intent.getStringExtra("obra") ?: ""
         val ano = intent.getStringExtra("ano") ?: ""
 
+        val nomeSuprimento = intent.getStringExtra("suprimento") ?: ""
+        val nomeProducao = intent.getStringExtra("produção")
+            ?: intent.getStringExtra("producao") ?: ""
+
         val montadoresPrefs = getSharedPreferences("config", MODE_PRIVATE)
             .getString("montadores", "") ?: ""
         val montadoresList = montadoresPrefs.split("\n").filter { it.isNotBlank() }
@@ -221,6 +225,11 @@ class ChecklistPosto01Parte2Activity : AppCompatActivity() {
             payload.put("obra", obra)
             payload.put("ano", ano)
             payload.put("itens", itens)
+            if (nomeSuprimento.isNotBlank()) {
+                payload.put("suprimento", nomeSuprimento)
+            } else if (nomeProducao.isNotBlank()) {
+                payload.put("produção", nomeProducao)
+            }
             Thread { enviarChecklist(payload) }.start()
             finish()
         }


### PR DESCRIPTION
## Summary
- capture optional "suprimento" or "produção" name from intent and include in payload
- attach sector information when posting Posto01 checklist

## Testing
- `./gradlew assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b104c694832f8d7a0f82c6b1fa47