### PR TITLE
Clean up stale checklist files and deduplicate project list

### DIFF
--- a/site/json_api/merge_checklists.py
+++ b/site/json_api/merge_checklists.py
@@ -210,6 +210,21 @@ def merge_directory(base_dir: str, output_dir: Optional[str] = None) -> List[Dic
             if prod_entries
             else None
         )
+
+        # remove older checklist files to avoid leftovers
+        for entry in sup_entries:
+            if sup is None or entry["path"] != sup["path"]:
+                try:
+                    os.remove(entry["path"])
+                except OSError:
+                    pass
+        for entry in prod_entries:
+            if prod is None or entry["path"] != prod["path"]:
+                try:
+                    os.remove(entry["path"])
+                except OSError:
+                    pass
+
         if not (sup and prod):
             continue
 


### PR DESCRIPTION
## Summary
- delete outdated checklist files for each obra when merging
- list only the most recent checklist per obra in `/projects` API

## Testing
- `python -m py_compile site/json_api/merge_checklists.py site/json_api/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2b3d60978832fb5891c89afc1a9ea