### PR TITLE
Allow extra production annotations in checklist comparison

### DIFF
--- a/site/json_api/merge_checklists.py
+++ b/site/json_api/merge_checklists.py
@@ -269,9 +269,10 @@ def find_mismatches(directory: str) -> List[Dict[str, Any]]:
     """Return merged checklists that have differing or missing answers.
 
     Looks for ``checklist_*.json`` files inside ``directory`` and checks each
-    item where ``suprimento`` or ``produção`` answers are missing/empty or
-    where both answers are present but differ. Only checklists containing at
-    least one divergence are returned.
+    item where ``suprimento`` or ``produção`` answers are missing/empty or where
+    the ``produção`` answer does not start with the ``suprimento`` answer.
+    Additional values present only in ``produção`` are ignored. Only checklists
+    containing at least one divergence are returned.
     """
 
     resultados: List[Dict[str, Any]] = []
@@ -290,9 +291,8 @@ def find_mismatches(directory: str) -> List[Dict[str, Any]]:
             sup = resp.get("suprimento")
             prod = resp.get("produção")
 
-            missing_sup = not sup
-            missing_prod = not prod
-            if missing_sup or missing_prod or sup != prod:
+            mismatch = not sup or not prod or prod[: len(sup)] != sup
+            if mismatch:
                 divergencias.append(
                     {
                         "numero": item.get("numero"),

--- a/tests/test_merge_checklists.py
+++ b/tests/test_merge_checklists.py
@@ -1,0 +1,62 @@
+"""Tests for merge_checklists helpers.
+
+These tests exercise the behavior of ``find_mismatches`` and
+``move_matching_checklists`` when the production checklist contains
+additional annotations beyond those found in the supply checklist.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "site" / "json_api" / "merge_checklists.py"
+spec = importlib.util.spec_from_file_location("merge_checklists", MODULE_PATH)
+merge = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(merge)  # type: ignore[misc]
+
+find_mismatches = merge.find_mismatches
+move_matching_checklists = merge.move_matching_checklists
+
+
+def _write_checklist(path: pathlib.Path, sup: list[str], prod: list[str]) -> None:
+    data = {
+        "obra": "OBRA1",
+        "ano": "2024",
+        "itens": [
+            {
+                "numero": 1,
+                "pergunta": "Pergunta",
+                "respostas": {"suprimento": sup, "produção": prod},
+            }
+        ],
+    }
+    with open(path, "w", encoding="utf-8") as fp:
+        json.dump(data, fp, ensure_ascii=False)
+
+
+def test_find_mismatches_ignores_additional_production_annotations(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "checklist_OBRA1.json"
+    _write_checklist(path, ["C", "Joao"], ["C", "Joao", "Maria"])
+
+    assert find_mismatches(str(tmp_path)) == []
+
+
+def test_move_matching_preserves_extra_annotations(tmp_path: pathlib.Path) -> None:
+    src_dir = tmp_path / "Posto01_Oficina"
+    src_dir.mkdir()
+    checklist_path = src_dir / "checklist_OBRA1.json"
+    _write_checklist(checklist_path, ["C", "Joao"], ["C", "Joao", "Maria"])
+
+    moved = move_matching_checklists(str(tmp_path))
+    assert moved == ["checklist_OBRA1.json"]
+
+    dest_path = tmp_path / "Posto02_Oficina" / "checklist_OBRA1.json"
+    with open(dest_path, "r", encoding="utf-8") as fp:
+        data = json.load(fp)
+
+    assert data["itens"][0]["respostas"]["produção"] == ["C", "Joao", "Maria"]
+    assert find_mismatches(str(tmp_path / "Posto02_Oficina")) == []
+


### PR DESCRIPTION
## Summary
- Treat production answers with additional annotations as matches when they start with the supply answer
- Document behavior for extra production values in `find_mismatches`
- Test non-divergent checklists with extra production annotations and movement to the next stage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2cc755e9c832f9ba1af2bfb90d2ec