### PR TITLE
Include montador checklists in merge

### DIFF
--- a/site/json_api/merge_checklists.py
+++ b/site/json_api/merge_checklists.py
@@ -198,7 +198,9 @@ def merge_directory(base_dir: str, output_dir: Optional[str] = None) -> List[Dic
         prod_entries = [
             e
             for e in entries
-            if "produção" in e["data"] or "producao" in e["data"]
+            if "produção" in e["data"]
+            or "producao" in e["data"]
+            or "montador" in e["data"]
         ]
         sup = (
             max(sup_entries, key=lambda e: os.path.getmtime(e["path"]))


### PR DESCRIPTION
## Summary
- treat checklists with `montador` entries as production files when merging

## Testing
- `pytest -q`
- `python site/json_api/merge_checklists.py site/json_api`


------
https://chatgpt.com/codex/tasks/task_e_68c4141e9ebc832f8c51ec9265f546c1