### PR TITLE
Add operator metadata to Posto checklists

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto01Parte2Activity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto01Parte2Activity.kt
@@ -214,14 +214,12 @@ class ChecklistPosto01Parte2Activity : AppCompatActivity() {
                     na.isChecked -> "NA"
                     else -> ""
                 }
-                val nome = spinners[idx].selectedItem.toString()
-                val resp = JSONArray().apply {
-                    put(option)
-                    put(nome)
-                }
-                val uniqueResp = JSONArray((0 until resp.length()).map { resp.getString(it) }.distinct())
-                val respostas = JSONObject().put("montador", uniqueResp)
+                val operadorNome = spinners[idx].selectedItem.toString()
+                val statusArray = JSONArray().apply { put(option) }
+                val uniqueStatus = JSONArray((0 until statusArray.length()).map { statusArray.getString(it) }.distinct())
+                val respostas = JSONObject().put("montador", uniqueStatus)
                 obj.put("respostas", respostas)
+                obj.put("montador", operadorNome)
                 itens.put(obj)
             }
             val payload = JSONObject()

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02Activity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02Activity.kt
@@ -147,14 +147,12 @@ class ChecklistPosto02Activity : AppCompatActivity() {
                     na.isChecked -> "NA"
                     else -> ""
                 }
-                val nome = spinners[idx].selectedItem.toString()
-                val resp = JSONArray().apply {
-                    put(option)
-                    put(nome)
-                }
-                val uniqueResp = JSONArray((0 until resp.length()).map { resp.getString(it) }.distinct())
-                val respostas = JSONObject().put("montador", uniqueResp)
+                val operadorNome = spinners[idx].selectedItem.toString()
+                val statusArray = JSONArray().apply { put(option) }
+                val uniqueStatus = JSONArray((0 until statusArray.length()).map { statusArray.getString(it) }.distinct())
+                val respostas = JSONObject().put("montador", uniqueStatus)
                 obj.put("respostas", respostas)
+                obj.put("montador", operadorNome)
                 itens.put(obj)
             }
             val payload = JSONObject()


### PR DESCRIPTION
## Summary
- send responses as `respostas` with status-only arrays
- attach operator name at the root of each checklist item

## Testing
- `python -m pytest -q`
- `python - <<'PY'
import sys
sys.path.append('site')
from json_api.merge_checklists import move_matching_checklists
print(move_matching_checklists('site/json_api'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c424ef0764832fb89eeb28f543c764