### PR TITLE
Include montador data in checklist merge

### DIFF
--- a/site/json_api/merge_checklists.py
+++ b/site/json_api/merge_checklists.py
@@ -31,7 +31,7 @@ def merge_checklists(json_suprimento: Dict[str, Any], json_producao: Dict[str, A
         "ano": ano,
         "respondentes": {
             "suprimento": _first_key(json_suprimento, ["suprimento", "produção", "producao"]),
-            "produção": _first_key(json_producao, ["produção", "producao", "suprimento"]),
+            "produção": _first_key(json_producao, ["montador", "produção", "producao", "suprimento"]),
         },
     }
 
@@ -61,7 +61,7 @@ def merge_checklists(json_suprimento: Dict[str, Any], json_producao: Dict[str, A
         if numero is None:
             continue
         pergunta = item.get("pergunta", "")
-        resposta = _extract_respostas(item, ["produção", "producao", "suprimento"])
+        resposta = _extract_respostas(item, ["montador", "produção", "producao", "suprimento"])
         entry = itens.setdefault(numero, {})
         entry["pergunta_prod"] = pergunta
         entry["res_prod"] = resposta

--- a/tests/test_merge_checklists.py
+++ b/tests/test_merge_checklists.py
@@ -45,6 +45,37 @@ def _write_checklist(path: pathlib.Path, sup: list[str], prod: list[str]) -> Non
         json.dump(data, fp, ensure_ascii=False)
 
 
+def test_merge_checklists_accepts_montador_key() -> None:
+    sup = {
+        "obra": "OBRA1",
+        "ano": "2024",
+        "suprimento": "Carlos",
+        "itens": [
+            {
+                "numero": 1,
+                "pergunta": "Pergunta",
+                "respostas": {"suprimento": ["C"]},
+            }
+        ],
+    }
+    prod = {
+        "obra": "OBRA1",
+        "ano": "2024",
+        "montador": "Joao",
+        "itens": [
+            {
+                "numero": 1,
+                "pergunta": "Pergunta",
+                "respostas": {"montador": ["C"]},
+            }
+        ],
+    }
+
+    merged = merge.merge_checklists(sup, prod)
+    assert merged["respondentes"]["produção"] == "Joao"
+    assert merged["itens"][0]["respostas"]["produção"] == ["C"]
+
+
 def test_find_mismatches_ignores_additional_production_annotations(tmp_path: pathlib.Path) -> None:
     path = tmp_path / "checklist_OBRA1.json"
     _write_checklist(path, ["C", "Joao"], ["C", "Joao", "Maria"])


### PR DESCRIPTION
## Summary
- allow production respondent detection to look for `montador`
- merge production item answers from `montador` key
- add regression test for montador-based merging

## Testing
- `python site/json_api/merge_checklists.py /tmp/merge_test_fkgrzha2`
- `python - <<'PY' ... move_matching_checklists('/tmp/merge_test_fkgrzha2') ... PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c42a7c3a14832f95c02af7f0484208