### PR TITLE
Add origem field to checklists and merge only for AppOficina

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/MainActivity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/MainActivity.kt
@@ -157,7 +157,7 @@ class ChecklistPosto01Parte2Activity : AppCompatActivity() {
             lifecycleScope.launch {
                 try {
                     val filePath = withContext(Dispatchers.IO) {
-                        val request = ChecklistRequest(obra, ano, suprimento, itensChecklist, materiais)
+                        val request = ChecklistRequest(obra, ano, suprimento, itensChecklist, materiais, "AppEstoque")
                         val response = JsonNetworkModule.api(this@ChecklistPosto01Parte2Activity).salvarChecklist(request)
                         if (pendentes == null) {
                             NetworkModule.api(this@ChecklistPosto01Parte2Activity).aprovarSolicitacao(id)

--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Activity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Activity.kt
@@ -179,7 +179,7 @@
                     lifecycleScope.launch {
                         try {
                             withContext(Dispatchers.IO) {
-                                val request = ChecklistRequest(obra, ano, suprimento, itensChecklist, materiais)
+                                val request = ChecklistRequest(obra, ano, suprimento, itensChecklist, materiais, "AppEstoque")
                                 JsonNetworkModule.api(this@ChecklistPosto01Activity).salvarChecklist(request)
                                 if (pendentes == null) {
                                     NetworkModule.api(this@ChecklistPosto01Activity).aprovarSolicitacao(id)

--- a/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Parte2Activity.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/checklist/ChecklistPosto01Parte2Activity.kt
@@ -143,7 +143,7 @@ class ChecklistPosto01Parte2Activity : AppCompatActivity() {
             lifecycleScope.launch {
                 try {
                     val filePath = withContext(Dispatchers.IO) {
-                        val request = ChecklistRequest(obra, ano, suprimento, itensChecklist, materiais)
+                        val request = ChecklistRequest(obra, ano, suprimento, itensChecklist, materiais, "AppEstoque")
                         val response = JsonNetworkModule.api(this@ChecklistPosto01Parte2Activity).salvarChecklist(request)
                         if (pendentes == null) {
                             NetworkModule.api(this@ChecklistPosto01Parte2Activity).aprovarSolicitacao(id)

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/ChecklistRequest.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/ChecklistRequest.kt
@@ -22,5 +22,6 @@ data class ChecklistRequest(
     val ano: String,
     val suprimento: String,
     val itens: List<ChecklistItem>,
-    val materiais: List<ChecklistMaterial>
+    val materiais: List<ChecklistMaterial>,
+    val origem: String
 )

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto01Parte2Activity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto01Parte2Activity.kt
@@ -226,6 +226,7 @@ class ChecklistPosto01Parte2Activity : AppCompatActivity() {
             payload.put("obra", obra)
             payload.put("ano", ano)
             payload.put("itens", itens)
+            payload.put("origem", "AppOficina")
             if (nomeProducao.isNotBlank()) {
                 payload.put("montador", nomeProducao)
             } else if (nomeSuprimento.isNotBlank()) {

--- a/site/json_api/__init__.py
+++ b/site/json_api/__init__.py
@@ -253,6 +253,7 @@ def _ensure_nc_preview(file_path: str) -> None:
 def salvar_checklist():
     """Save a checklist payload to a timestamped JSON file."""
     data = request.get_json() or {}
+    origem = data.get('origem', 'AppEstoque')
     obra = data.get('obra', 'desconhecida')
 
     os.makedirs(BASE_DIR, exist_ok=True)
@@ -263,8 +264,10 @@ def salvar_checklist():
 
     with open(file_path, 'w', encoding='utf-8') as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
-    merge_directory(BASE_DIR)
-    move_matching_checklists(BASE_DIR)
+
+    if origem == 'AppOficina':
+        merge_directory(BASE_DIR)
+        move_matching_checklists(BASE_DIR)
 
     return jsonify({'caminho': file_path})
 

--- a/tests/test_checklist_origin.py
+++ b/tests/test_checklist_origin.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+import pathlib
+from flask import Flask
+
+import importlib
+import sys
+
+SITE_DIR = pathlib.Path(__file__).resolve().parents[1] / "site"
+sys.path.insert(0, str(SITE_DIR))
+api = importlib.import_module("json_api")
+
+
+def _client(tmp_path: pathlib.Path):
+    api.BASE_DIR = str(tmp_path)
+    app = Flask(__name__)
+    app.register_blueprint(api.bp)
+    return app.test_client()
+
+
+def test_salvar_checklist_appestoque_does_not_merge(tmp_path: pathlib.Path, monkeypatch):
+    called = {"merge": 0, "move": 0}
+
+    def fake_merge(directory: str) -> None:
+        called["merge"] += 1
+
+    def fake_move(directory: str) -> None:
+        called["move"] += 1
+
+    monkeypatch.setattr(api, "merge_directory", fake_merge)
+    monkeypatch.setattr(api, "move_matching_checklists", fake_move)
+
+    client = _client(tmp_path)
+    payload = {"obra": "OBRA1", "origem": "AppEstoque"}
+    res = client.post("/checklist", json=payload)
+    assert res.status_code == 200
+    assert called == {"merge": 0, "move": 0}
+
+
+def test_salvar_checklist_appoficina_triggers_merge(tmp_path: pathlib.Path, monkeypatch):
+    called = {"merge": 0, "move": 0}
+
+    def fake_merge(directory: str) -> None:
+        called["merge"] += 1
+
+    def fake_move(directory: str) -> None:
+        called["move"] += 1
+
+    monkeypatch.setattr(api, "merge_directory", fake_merge)
+    monkeypatch.setattr(api, "move_matching_checklists", fake_move)
+
+    client = _client(tmp_path)
+    payload = {"obra": "OBRA1", "origem": "AppOficina"}
+    res = client.post("/checklist", json=payload)
+    assert res.status_code == 200
+    assert called["merge"] == 1
+    assert called["move"] == 1


### PR DESCRIPTION
## Summary
- save `origem` in checklist payloads so API knows if data comes from AppEstoque or AppOficina
- AppEstoque and AppOficina now send their respective `origem` values
- merge checklists only when origin is `AppOficina`
- test that merge runs only for AppOficina submissions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7ecd0893c832f868f571099053a06