### PR TITLE
Handle updated posto02 respostas format and capture montador name

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02Activity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02Activity.kt
@@ -25,6 +25,7 @@ class ChecklistPosto02Activity : AppCompatActivity() {
         val obra = intent.getStringExtra("obra") ?: ""
         val ano = intent.getStringExtra("ano") ?: ""
 
+        val nomeMontador = intent.getStringExtra("montador") ?: ""
         val nomeSuprimento = intent.getStringExtra("suprimento") ?: ""
         val nomeProducao = intent.getStringExtra("produção")
             ?: intent.getStringExtra("producao") ?: ""
@@ -159,7 +160,9 @@ class ChecklistPosto02Activity : AppCompatActivity() {
             payload.put("obra", obra)
             payload.put("ano", ano)
             payload.put("itens", itens)
-            if (nomeProducao.isNotBlank()) {
+            if (nomeMontador.isNotBlank()) {
+                payload.put("montador", nomeMontador)
+            } else if (nomeProducao.isNotBlank()) {
                 payload.put("montador", nomeProducao)
             } else if (nomeSuprimento.isNotBlank()) {
                 payload.put("suprimento", nomeSuprimento)

--- a/AppOficina/app/src/main/java/com/example/appoficina/Posto02OficinaFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/Posto02OficinaFragment.kt
@@ -80,10 +80,13 @@ class Posto02OficinaFragment : Fragment() {
                                             intent.putExtra("tipo", "posto02")
                                             startActivity(intent)
                                         } else {
-                                            val intent = Intent(requireContext(), ChecklistPosto02Activity::class.java)
-                                            intent.putExtra("obra", obra)
-                                            intent.putExtra("ano", ano)
-                                            startActivity(intent)
+                                            promptName(requireContext(), "Nome do montador") { nome ->
+                                                val intent = Intent(requireContext(), ChecklistPosto02Activity::class.java)
+                                                intent.putExtra("obra", obra)
+                                                intent.putExtra("ano", ano)
+                                                intent.putExtra("montador", nome)
+                                                startActivity(intent)
+                                            }
                                         }
                                     }
                                 }.start()

--- a/AppOficina/app/src/main/java/com/example/appoficina/PreviewDivergenciasActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/PreviewDivergenciasActivity.kt
@@ -101,11 +101,22 @@ class PreviewDivergenciasActivity : AppCompatActivity() {
                     "posto06_cablagem" -> ChecklistPosto06Cablagem02Activity::class.java
                     else -> ChecklistPosto02Activity::class.java
                 }
-                val intent = Intent(this, clazz)
-                intent.putExtra("obra", obra)
-                intent.putExtra("ano", ano)
-                startActivity(intent)
-                finish()
+                if (tipo == "posto02") {
+                    promptName(this, "Nome do montador") { nome ->
+                        val intent = Intent(this, clazz)
+                        intent.putExtra("obra", obra)
+                        intent.putExtra("ano", ano)
+                        intent.putExtra("montador", nome)
+                        startActivity(intent)
+                        finish()
+                    }
+                } else {
+                    val intent = Intent(this, clazz)
+                    intent.putExtra("obra", obra)
+                    intent.putExtra("ano", ano)
+                    startActivity(intent)
+                    finish()
+                }
             }
         }
     }

--- a/site/json_api/__init__.py
+++ b/site/json_api/__init__.py
@@ -735,7 +735,10 @@ def posto02_upload():
     for item in data.get('itens', []):
         numero = item.get('numero')
         pergunta = item.get('pergunta')
-        resposta = item.get('resposta') if isinstance(item.get('resposta'), list) else None
+        respostas = item.get("respostas") or {}
+        resposta = respostas.get("montador") or (
+            item.get("resposta") if isinstance(item.get("resposta"), list) else None
+        )
         itens.append({
             'numero': numero,
             'pergunta': pergunta,

--- a/tests/test_merge_checklists.py
+++ b/tests/test_merge_checklists.py
@@ -76,21 +76,34 @@ def test_merge_checklists_accepts_montador_key() -> None:
 
 
 def test_merge_checklists_handles_multiple_montadores() -> None:
+    sup = {
+        "obra": "OBRA1",
+        "ano": "2024",
+        "suprimento": "Carlos",
+        "itens": [
+            {
+                "numero": 1,
+                "pergunta": "Pergunta",
+                "respostas": {"suprimento": ["C"]},
+            }
+        ],
+    }
     prod = {
         "obra": "OBRA1",
         "ano": "2024",
+        "montador": "Joao",
         "itens": [
             {
                 "numero": 1,
                 "pergunta": "Pergunta",
                 "montador": "Joao",
-                "respostas": {"montador": ["Ok"]},
+                "respostas": {"montador": ["C"]},
             },
             {
                 "numero": 2,
-                "pergunta": "Pergunta",
+                "pergunta": "Outra",
                 "montador": "Maria",
-                "respostas": {"montador": ["Ok"]},
+                "respostas": {"montador": ["C"]},
             },
         ],
     }

--- a/tests/test_posto02_upload_inspection.py
+++ b/tests/test_posto02_upload_inspection.py
@@ -1,0 +1,49 @@
+import json
+import pathlib
+import importlib
+import sys
+from flask import Flask
+
+SITE_DIR = pathlib.Path(__file__).resolve().parents[1] / "site"
+sys.path.insert(0, str(SITE_DIR))
+api = importlib.import_module("json_api")
+
+
+def _client(tmp_path: pathlib.Path):
+    api.BASE_DIR = str(tmp_path)
+    app = Flask(__name__)
+    app.register_blueprint(api.bp)
+    return app.test_client()
+
+
+def test_upload_and_inspection_without_divergencias(tmp_path):
+    # Prepare base file expected by upload endpoint
+    src_dir = tmp_path / "Posto02_Oficina"
+    src_dir.mkdir()
+    with open(src_dir / "checklist_OBRA1.json", "w", encoding="utf-8") as f:
+        json.dump({"obra": "OBRA1"}, f)
+
+    client = _client(tmp_path)
+
+    upload_payload = {
+        "obra": "OBRA1",
+        "montador": "Joao",
+        "itens": [
+            {"numero": 1, "pergunta": "Pergunta1", "respostas": {"montador": ["C"]}},
+            {"numero": 2, "pergunta": "Pergunta2", "resposta": ["C"]},
+        ],
+    }
+    res = client.post("/posto02/upload", json=upload_payload)
+    assert res.status_code == 200
+
+    insp_payload = {
+        "obra": "OBRA1",
+        "inspetor": "Maria",
+        "itens": [
+            {"numero": 1, "pergunta": "Pergunta1", "resposta": ["C"]},
+            {"numero": 2, "pergunta": "Pergunta2", "resposta": ["C"]},
+        ],
+    }
+    res_insp = client.post("/posto02/insp/upload", json=insp_payload)
+    assert res_insp.status_code == 200
+    assert res_insp.get_json()["divergencias"] == []


### PR DESCRIPTION
## Summary
- Support both new `respostas.montador` and legacy `resposta` fields when uploading Posto02 checklists
- Add regression test ensuring montador and inspetor agreement yields no divergencias
- Fix existing merge checklist test coverage for multiple montadores
- Prompt for montador name in AppOficina Posto02 flow and include it in upload payload

## Testing
- `pytest -q`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c808b01808832faa8f74d7294cbf97