### PR TITLE
Capture montador name per item in Posto02 checklist

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02Activity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02Activity.kt
@@ -25,10 +25,6 @@ class ChecklistPosto02Activity : AppCompatActivity() {
         val obra = intent.getStringExtra("obra") ?: ""
         val ano = intent.getStringExtra("ano") ?: ""
 
-        val nomeSuprimento = intent.getStringExtra("suprimento") ?: ""
-        val nomeProducao = intent.getStringExtra("produção")
-            ?: intent.getStringExtra("producao") ?: ""
-
         val montadoresPrefs = getSharedPreferences("config", MODE_PRIVATE)
             .getString("montadores", "") ?: ""
         val montadoresList = montadoresPrefs.split("\n").filter { it.isNotBlank() }
@@ -148,9 +144,7 @@ class ChecklistPosto02Activity : AppCompatActivity() {
                     else -> ""
                 }
                 val operadorNome = spinners[idx].selectedItem.toString()
-                val statusArray = JSONArray().apply { put(option) }
-                val uniqueStatus = JSONArray((0 until statusArray.length()).map { statusArray.getString(it) }.distinct())
-                val respostas = JSONObject().put("montador", uniqueStatus)
+                val respostas = JSONObject().put("montador", JSONArray().put(option))
                 obj.put("respostas", respostas)
                 obj.put("montador", operadorNome)
                 itens.put(obj)
@@ -159,11 +153,6 @@ class ChecklistPosto02Activity : AppCompatActivity() {
             payload.put("obra", obra)
             payload.put("ano", ano)
             payload.put("itens", itens)
-            if (nomeProducao.isNotBlank()) {
-                payload.put("montador", nomeProducao)
-            } else if (nomeSuprimento.isNotBlank()) {
-                payload.put("suprimento", nomeSuprimento)
-            }
             Thread { enviarChecklist(payload) }.start()
             finish()
         }

--- a/site/json_api/__init__.py
+++ b/site/json_api/__init__.py
@@ -735,15 +735,18 @@ def posto02_upload():
     for item in data.get('itens', []):
         numero = item.get('numero')
         pergunta = item.get('pergunta')
-        resposta = item.get('resposta') if isinstance(item.get('resposta'), list) else None
+        respostas = item.get("respostas") or {}
+        resposta = respostas.get("montador") or (
+            item.get("resposta") if isinstance(item.get("resposta"), list) else None
+        )
         itens.append({
             'numero': numero,
             'pergunta': pergunta,
+            'montador': item.get('montador'),
             'respostas': {'montador': resposta},
         })
 
     base['posto02'] = {
-        'montador': data.get('montador'),
         'itens': itens,
     }
 

--- a/tests/test_merge_checklists.py
+++ b/tests/test_merge_checklists.py
@@ -76,21 +76,34 @@ def test_merge_checklists_accepts_montador_key() -> None:
 
 
 def test_merge_checklists_handles_multiple_montadores() -> None:
+    sup = {
+        "obra": "OBRA1",
+        "ano": "2024",
+        "suprimento": "Carlos",
+        "itens": [
+            {
+                "numero": 1,
+                "pergunta": "Pergunta",
+                "respostas": {"suprimento": ["C"]},
+            }
+        ],
+    }
     prod = {
         "obra": "OBRA1",
         "ano": "2024",
+        "montador": "Joao",
         "itens": [
             {
                 "numero": 1,
                 "pergunta": "Pergunta",
                 "montador": "Joao",
-                "respostas": {"montador": ["Ok"]},
+                "respostas": {"montador": ["C"]},
             },
             {
                 "numero": 2,
-                "pergunta": "Pergunta",
+                "pergunta": "Outra",
                 "montador": "Maria",
-                "respostas": {"montador": ["Ok"]},
+                "respostas": {"montador": ["C"]},
             },
         ],
     }

--- a/tests/test_posto02_upload_inspection.py
+++ b/tests/test_posto02_upload_inspection.py
@@ -1,0 +1,62 @@
+import json
+import pathlib
+import importlib
+import sys
+from flask import Flask
+
+SITE_DIR = pathlib.Path(__file__).resolve().parents[1] / "site"
+sys.path.insert(0, str(SITE_DIR))
+api = importlib.import_module("json_api")
+
+
+def _client(tmp_path: pathlib.Path):
+    api.BASE_DIR = str(tmp_path)
+    app = Flask(__name__)
+    app.register_blueprint(api.bp)
+    return app.test_client()
+
+
+def test_upload_and_inspection_without_divergencias(tmp_path):
+    # Prepare base file expected by upload endpoint
+    src_dir = tmp_path / "Posto02_Oficina"
+    src_dir.mkdir()
+    with open(src_dir / "checklist_OBRA1.json", "w", encoding="utf-8") as f:
+        json.dump({"obra": "OBRA1"}, f)
+
+    client = _client(tmp_path)
+
+    upload_payload = {
+        "obra": "OBRA1",
+        "itens": [
+            {
+                "numero": 1,
+                "pergunta": "Pergunta1",
+                "montador": "Joao",
+                "respostas": {"montador": ["C"]},
+            },
+            {
+                "numero": 2,
+                "pergunta": "Pergunta2",
+                "montador": "Joao",
+                "resposta": ["C"],
+            },
+        ],
+    }
+    res = client.post("/posto02/upload", json=upload_payload)
+    assert res.status_code == 200
+    saved = tmp_path / "Posto02_Oficina" / "Posto02_Oficina_Inspetor" / "checklist_OBRA1.json"
+    with open(saved, "r", encoding="utf-8") as f:
+        stored = json.load(f)
+    assert stored["posto02"]["itens"][0]["montador"] == "Joao"
+
+    insp_payload = {
+        "obra": "OBRA1",
+        "inspetor": "Maria",
+        "itens": [
+            {"numero": 1, "pergunta": "Pergunta1", "resposta": ["C"]},
+            {"numero": 2, "pergunta": "Pergunta2", "resposta": ["C"]},
+        ],
+    }
+    res_insp = client.post("/posto02/insp/upload", json=insp_payload)
+    assert res_insp.status_code == 200
+    assert res_insp.get_json()["divergencias"] == []


### PR DESCRIPTION
## Summary
- Simplify per-item Posto02 checklist payload to place montador answers directly in a single JSON array
- Maintain item-level montador name without any initial global prompt

## Testing
- `pytest -q`
- `cd AppOficina && ./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c808b01808832faa8f74d7294cbf97