### PR TITLE
Streamline Posto02 checklist operator handling

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02Activity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02Activity.kt
@@ -2,13 +2,9 @@ package com.example.appoficina
 
 import android.content.Context
 import android.os.Bundle
-import android.view.View
-import android.widget.AdapterView
-import android.widget.ArrayAdapter
 import android.widget.Button
 import android.widget.CheckBox
 import android.widget.LinearLayout
-import android.widget.Spinner
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import org.json.JSONArray
@@ -24,10 +20,7 @@ class ChecklistPosto02Activity : AppCompatActivity() {
 
         val obra = intent.getStringExtra("obra") ?: ""
         val ano = intent.getStringExtra("ano") ?: ""
-
-        val montadoresPrefs = getSharedPreferences("config", MODE_PRIVATE)
-            .getString("montadores", "") ?: ""
-        val montadoresList = montadoresPrefs.split("\n").filter { it.isNotBlank() }
+        val operadorNome = intent.getStringExtra("montador") ?: ""
 
         val perguntas = listOf(
             "2.1 - PORTAS: Identificação do projeto",
@@ -59,13 +52,12 @@ class ChecklistPosto02Activity : AppCompatActivity() {
 
         val container = findViewById<LinearLayout>(R.id.questions_container)
         val triplets = mutableListOf<Triple<CheckBox, CheckBox, CheckBox>>()
-        val spinners = mutableListOf<Spinner>()
         val concluirButton = findViewById<Button>(R.id.btnConcluirPosto02)
 
         fun updateButtonState() {
             concluirButton.isEnabled = triplets.all { (c, nc, na) ->
                 c.isChecked || nc.isChecked || na.isChecked
-            } && spinners.all { it.selectedItem != null }
+            }
         }
 
         perguntas.forEach { pergunta ->
@@ -87,22 +79,6 @@ class ChecklistPosto02Activity : AppCompatActivity() {
             row.addView(na)
             container.addView(row)
             triplets.add(Triple(c, nc, na))
-
-            val spinner = Spinner(this)
-            spinner.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_item, montadoresList).also {
-                it.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
-            }
-            spinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
-                override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
-                    updateButtonState()
-                }
-
-                override fun onNothingSelected(parent: AdapterView<*>) {
-                    updateButtonState()
-                }
-            }
-            container.addView(spinner)
-            spinners.add(spinner)
         }
 
         triplets.forEach { (c, nc, na) ->
@@ -143,10 +119,11 @@ class ChecklistPosto02Activity : AppCompatActivity() {
                     na.isChecked -> "NA"
                     else -> ""
                 }
-                val operadorNome = spinners[idx].selectedItem.toString()
-                val respostas = JSONObject().put("montador", JSONArray().put(option))
+                val respostas = JSONObject().put(
+                    "montador",
+                    JSONArray().put(option).put(operadorNome)
+                )
                 obj.put("respostas", respostas)
-                obj.put("operadorNome", operadorNome)
                 itens.put(obj)
             }
             val payload = JSONObject()


### PR DESCRIPTION
## Summary
- remove per-question montador selection from Posto02 checklist
- send operator name alongside each montador response in checklist payload

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8295c2140832fb9772194dbbca746