### PR TITLE
Streamline Posto02 operator handling and restore inspector prompt

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02Activity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02Activity.kt
@@ -2,13 +2,9 @@ package com.example.appoficina
 
 import android.content.Context
 import android.os.Bundle
-import android.view.View
-import android.widget.AdapterView
-import android.widget.ArrayAdapter
 import android.widget.Button
 import android.widget.CheckBox
 import android.widget.LinearLayout
-import android.widget.Spinner
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import org.json.JSONArray
@@ -24,10 +20,7 @@ class ChecklistPosto02Activity : AppCompatActivity() {
 
         val obra = intent.getStringExtra("obra") ?: ""
         val ano = intent.getStringExtra("ano") ?: ""
-
-        val montadoresPrefs = getSharedPreferences("config", MODE_PRIVATE)
-            .getString("montadores", "") ?: ""
-        val montadoresList = montadoresPrefs.split("\n").filter { it.isNotBlank() }
+        val operadorNome = intent.getStringExtra("montador") ?: ""
 
         val perguntas = listOf(
             "2.1 - PORTAS: Identificação do projeto",
@@ -59,13 +52,12 @@ class ChecklistPosto02Activity : AppCompatActivity() {
 
         val container = findViewById<LinearLayout>(R.id.questions_container)
         val triplets = mutableListOf<Triple<CheckBox, CheckBox, CheckBox>>()
-        val spinners = mutableListOf<Spinner>()
         val concluirButton = findViewById<Button>(R.id.btnConcluirPosto02)
 
         fun updateButtonState() {
             concluirButton.isEnabled = triplets.all { (c, nc, na) ->
                 c.isChecked || nc.isChecked || na.isChecked
-            } && spinners.all { it.selectedItem != null }
+            }
         }
 
         perguntas.forEach { pergunta ->
@@ -87,22 +79,6 @@ class ChecklistPosto02Activity : AppCompatActivity() {
             row.addView(na)
             container.addView(row)
             triplets.add(Triple(c, nc, na))
-
-            val spinner = Spinner(this)
-            spinner.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_item, montadoresList).also {
-                it.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
-            }
-            spinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
-                override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
-                    updateButtonState()
-                }
-
-                override fun onNothingSelected(parent: AdapterView<*>) {
-                    updateButtonState()
-                }
-            }
-            container.addView(spinner)
-            spinners.add(spinner)
         }
 
         triplets.forEach { (c, nc, na) ->
@@ -143,10 +119,11 @@ class ChecklistPosto02Activity : AppCompatActivity() {
                     na.isChecked -> "NA"
                     else -> ""
                 }
-                val operadorNome = spinners[idx].selectedItem.toString()
-                val respostas = JSONObject().put("montador", JSONArray().put(option))
+                val respostas = JSONObject().put(
+                    "montador",
+                    JSONArray().put(option).put(operadorNome)
+                )
                 obj.put("respostas", respostas)
-                obj.put("operadorNome", operadorNome)
                 itens.put(obj)
             }
             val payload = JSONObject()

--- a/AppOficina/app/src/main/java/com/example/appoficina/Posto02InspetorFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/Posto02InspetorFragment.kt
@@ -81,10 +81,13 @@ class Posto02InspetorFragment : Fragment() {
                                             intent.putExtra("tipo", "insp_posto02")
                                             startActivity(intent)
                                         } else {
-                                            val intent = Intent(requireContext(), ChecklistPosto02InspActivity::class.java)
-                                            intent.putExtra("obra", obra)
-                                            intent.putExtra("ano", ano)
-                                            startActivity(intent)
+                                            promptName(requireContext(), "Nome do inspetor") { nome ->
+                                                val intent = Intent(requireContext(), ChecklistPosto02InspActivity::class.java)
+                                                intent.putExtra("obra", obra)
+                                                intent.putExtra("ano", ano)
+                                                intent.putExtra("inspetor", nome)
+                                                startActivity(intent)
+                                            }
                                         }
                                     }
                                 }.start()

--- a/AppOficina/app/src/main/java/com/example/appoficina/PreviewDivergenciasActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/PreviewDivergenciasActivity.kt
@@ -68,19 +68,14 @@ class PreviewDivergenciasActivity : AppCompatActivity() {
             else -> actionButton.text
         }
         actionButton.setOnClickListener {
-            if (tipo == "insp_posto02") {
-                val intent = Intent(this, ChecklistPosto02InspActivity::class.java)
-                intent.putExtra("obra", obra)
-                intent.putExtra("ano", ano)
-                startActivity(intent)
-                finish()
-            } else if (tipo.startsWith("insp_") || tipo == "posto08_iqm") {
+            if (tipo.startsWith("insp_") || tipo == "posto08_iqm") {
                 val titulo = "Nome do inspetor"
                 promptName(this, titulo) { nome ->
                     if (tipo == "posto08_iqm") {
                         Thread { marcarDivergenciasTratadas(obra) }.start()
                     }
                     val (clazz, extraName) = when (tipo) {
+                        "insp_posto02" -> ChecklistPosto02InspActivity::class.java to "inspetor"
                         "insp_posto03_pre" -> ChecklistPosto03PreInspActivity::class.java to "inspetor"
                         "insp_posto04_barramento" -> ChecklistPosto04BarramentoInspActivity::class.java to "inspetor"
                         "insp_posto05_cablagem" -> ChecklistPosto05CablagemInspActivity::class.java to "inspetor"


### PR DESCRIPTION
## Summary
- send montador name with each Posto02 answer instead of prompting per question
- prompt for inspector name again when starting Posto02 inspections
- retain montador name prompt when launching Posto02 checklist

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c8295c2140832fb9772194dbbca746