### PR TITLE
Separate montador names from checklist status arrays

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02Activity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02Activity.kt
@@ -143,7 +143,7 @@ class ChecklistPosto02Activity : AppCompatActivity() {
                 val montadorSelecionado = spinners[idx].selectedItem?.toString() ?: ""
                 val respostas = JSONObject().put(
                     "montador",
-                    JSONArray().put(option).put(montadorSelecionado)
+                    JSONArray().put(option)
                 )
                 obj.put("respostas", respostas)
                 obj.put("montador", montadorSelecionado)

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto03PreActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto03PreActivity.kt
@@ -129,8 +129,8 @@ class ChecklistPosto03PreActivity : AppCompatActivity() {
                 val obj = JSONObject()
                 obj.put("numero", 301 + idx)
                 obj.put("pergunta", perguntas[idx])
-                val resp = JSONArray()
-                resp.put(
+                val montadorSelecionado = spinners[idx].selectedItem.toString()
+                val resp = JSONArray().put(
                     when {
                         c.isChecked -> "C"
                         nc.isChecked -> "NC"
@@ -138,9 +138,8 @@ class ChecklistPosto03PreActivity : AppCompatActivity() {
                         else -> ""
                     }
                 )
-                resp.put(spinners[idx].selectedItem.toString())
                 obj.put("resposta", resp)
-                obj.put("montador", spinners[idx].selectedItem.toString())
+                obj.put("montador", montadorSelecionado)
                 itens.put(obj)
             }
             val payload = JSONObject()

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto04BarramentoActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto04BarramentoActivity.kt
@@ -117,8 +117,8 @@ class ChecklistPosto04BarramentoActivity : AppCompatActivity() {
                 val obj = JSONObject()
                 obj.put("numero", 401 + idx)
                 obj.put("pergunta", perguntas[idx])
-                val resp = JSONArray()
-                resp.put(
+                val montadorSelecionado = spinners[idx].selectedItem.toString()
+                val resp = JSONArray().put(
                     when {
                         c.isChecked -> "C"
                         nc.isChecked -> "NC"
@@ -126,9 +126,8 @@ class ChecklistPosto04BarramentoActivity : AppCompatActivity() {
                         else -> ""
                     }
                 )
-                resp.put(spinners[idx].selectedItem.toString())
                 obj.put("resposta", resp)
-                obj.put("montador", spinners[idx].selectedItem.toString())
+                obj.put("montador", montadorSelecionado)
                 itens.put(obj)
             }
             val payload = JSONObject()

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto05CablagemActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto05CablagemActivity.kt
@@ -118,8 +118,8 @@ class ChecklistPosto05CablagemActivity : AppCompatActivity() {
                 val obj = JSONObject()
                 obj.put("numero", 501 + idx)
                 obj.put("pergunta", perguntas[idx])
-                val resp = JSONArray()
-                resp.put(
+                val montadorSelecionado = spinners[idx].selectedItem.toString()
+                val resp = JSONArray().put(
                     when {
                         c.isChecked -> "C"
                         nc.isChecked -> "NC"
@@ -127,9 +127,8 @@ class ChecklistPosto05CablagemActivity : AppCompatActivity() {
                         else -> ""
                     }
                 )
-                resp.put(spinners[idx].selectedItem.toString())
                 obj.put("resposta", resp)
-                obj.put("montador", spinners[idx].selectedItem.toString())
+                obj.put("montador", montadorSelecionado)
                 itens.put(obj)
             }
             val payload = JSONObject()

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto06Cablagem02Activity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto06Cablagem02Activity.kt
@@ -117,8 +117,8 @@ class ChecklistPosto06Cablagem02Activity : AppCompatActivity() {
                 val obj = JSONObject()
                 obj.put("numero", 608 + idx)
                 obj.put("pergunta", perguntas[idx])
-                val resp = JSONArray()
-                resp.put(
+                val montadorSelecionado = spinners[idx].selectedItem.toString()
+                val resp = JSONArray().put(
                     when {
                         c.isChecked -> "C"
                         nc.isChecked -> "NC"
@@ -126,9 +126,8 @@ class ChecklistPosto06Cablagem02Activity : AppCompatActivity() {
                         else -> ""
                     }
                 )
-                resp.put(spinners[idx].selectedItem.toString())
                 obj.put("resposta", resp)
-                obj.put("montador", spinners[idx].selectedItem.toString())
+                obj.put("montador", montadorSelecionado)
                 itens.put(obj)
             }
             val payload = JSONObject()

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto06PreActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto06PreActivity.kt
@@ -118,8 +118,8 @@ class ChecklistPosto06PreActivity : AppCompatActivity() {
                 val obj = JSONObject()
                 obj.put("numero", 601 + idx)
                 obj.put("pergunta", perguntas[idx])
-                val resp = JSONArray()
-                resp.put(
+                val montadorSelecionado = spinners[idx].selectedItem.toString()
+                val resp = JSONArray().put(
                     when {
                         c.isChecked -> "C"
                         nc.isChecked -> "NC"
@@ -127,9 +127,8 @@ class ChecklistPosto06PreActivity : AppCompatActivity() {
                         else -> ""
                     }
                 )
-                resp.put(spinners[idx].selectedItem.toString())
                 obj.put("resposta", resp)
-                obj.put("montador", spinners[idx].selectedItem.toString())
+                obj.put("montador", montadorSelecionado)
                 itens.put(obj)
             }
             val payload = JSONObject()


### PR DESCRIPTION
## Summary
- ensure Posto 02 responses only send the status code in the respostas array
- update demais checklists de montagem para deixar o nome do montador fora do array de status

## Testing
- ./gradlew assembleDebug *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c9650ad8a8832f97d08035d9e39708