### PR TITLE
Format checklist status markers separately

### DIFF
--- a/tests/test_checklist_rendering.py
+++ b/tests/test_checklist_rendering.py
@@ -1,0 +1,13 @@
+import pathlib
+import sys
+
+SITE_DIR = pathlib.Path(__file__).resolve().parents[1] / "site"
+sys.path.insert(0, str(SITE_DIR))
+
+from projetista import format_status_with_names  # noqa: E402
+
+
+def test_format_status_with_names_highlights_status_first():
+    payload = {"suprimento": ["C", "victorr"]}
+    formatted = format_status_with_names(payload["suprimento"])
+    assert formatted == "C — victorr"


### PR DESCRIPTION
## Summary
- highlight checklist status markers separately from responder names when rendering table rows
- add a reusable helper for formatting status/name values and reuse the shared status marker set
- cover the new formatting with a checklist rendering helper test

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ca99d260c4832f9ad9a5e8c173ceb6