### PR TITLE
Handle AppOficina origin in merge detection

### DIFF
--- a/site/json_api/merge_checklists.py
+++ b/site/json_api/merge_checklists.py
@@ -292,6 +292,9 @@ def merge_directory(base_dir: str, output_dir: Optional[str] = None) -> List[Dic
 
         def _is_production(entry: Dict[str, Any]) -> bool:
             data = entry["data"]
+            origem = str(data.get("origem", "")).strip().lower()
+            if origem == "appoficina":
+                return True
             if any(k in data for k in ("produção", "producao", "montador")):
                 return True
             for item in data.get("itens", []) or []:

--- a/tests/test_merge_checklists.py
+++ b/tests/test_merge_checklists.py
@@ -217,6 +217,54 @@ def test_merge_directory_detects_production_in_item_respostas(tmp_path: pathlib.
         "montador": ["J"],
     }
 
+
+def test_merge_directory_handles_appoficina_origin(tmp_path: pathlib.Path) -> None:
+    sup = {
+        "obra": "OBRA1",
+        "ano": "2024",
+        "suprimento": "Carlos",
+        "itens": [
+            {
+                "numero": 1,
+                "pergunta": "Pergunta",
+                "respostas": {"suprimento": ["C"]},
+            }
+        ],
+    }
+    prod = {
+        "obra": "OBRA1",
+        "ano": "2024",
+        "origem": "AppOficina",
+        "itens": [
+            {
+                "numero": 1,
+                "pergunta": "Pergunta",
+                "resposta": ["OK"],
+            }
+        ],
+    }
+
+    sup_path = tmp_path / "sup_OBRA1.json"
+    prod_path = tmp_path / "20240102T120000_OBRA1.json"
+    with open(sup_path, "w", encoding="utf-8") as fp:
+        json.dump(sup, fp, ensure_ascii=False)
+    with open(prod_path, "w", encoding="utf-8") as fp:
+        json.dump(prod, fp, ensure_ascii=False)
+
+    merged = merge.merge_directory(str(tmp_path))
+    assert len(merged) == 1
+
+    out_path = tmp_path / "Posto01_Oficina" / "checklist_OBRA1.json"
+    with open(out_path, "r", encoding="utf-8") as fp:
+        data = json.load(fp)
+
+    assert data["itens"][0]["respostas"] == {
+        "suprimento": ["C", "Carlos"],
+        "montador": ["OK"],
+    }
+    assert not sup_path.exists()
+    assert not prod_path.exists()
+
 def test_posto02_inspector_allows_extra_annotations(tmp_path: pathlib.Path) -> None:
     api.BASE_DIR = str(tmp_path)
     insp_dir = tmp_path / "Posto02_Oficina" / "Posto02_Oficina_Inspetor"


### PR DESCRIPTION
## Summary
- treat AppOficina-origin checklists as production when merging directories
- add regression ensuring AppOficina files merge and original JSONs are removed

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68caa21f0260832f87f764acfb017216