### PR TITLE
Normalize AppEstoque supply roles in checklist merge

### DIFF
--- a/site/json_api/merge_checklists.py
+++ b/site/json_api/merge_checklists.py
@@ -72,28 +72,77 @@ def merge_checklists(json_suprimento: Dict[str, Any], json_producao: Dict[str, A
         },
     }
 
-    itens: Dict[int, Dict[str, Any]] = {}
-    itens_por_pergunta: Dict[str, List[int]] = {}
+    buckets: Dict[str, Dict[str, Any]] = {}
+
+    def _bucket_for(pergunta: str) -> Dict[str, Any]:
+        bucket = buckets.setdefault(
+            pergunta,
+            {
+                "numeros": set(),
+                "pergunta_sup": "",
+                "pergunta_prod": "",
+                "pergunta_final": pergunta,
+                "res_sup": None,
+                "res_prod": None,
+            },
+        )
+        if pergunta and len(pergunta) > len(bucket.get("pergunta_final", "")):
+            bucket["pergunta_final"] = pergunta
+        return bucket
+
+    def _update_pergunta(bucket: Dict[str, Any], chave: str, texto: str) -> None:
+        if texto and len(texto) > len(bucket.get(chave, "")):
+            bucket[chave] = texto
+            if len(texto) > len(bucket.get("pergunta_final", "")):
+                bucket["pergunta_final"] = texto
+
+    def _merge_dict(
+        a: Optional[Dict[str, List[str]]], b: Optional[Dict[str, List[str]]]
+    ) -> Optional[Dict[str, List[str]]]:
+        return _merge_respostas(a, b)
 
     def _extract_respostas(
-        item: Dict[str, Any], keys: List[str], parent: Dict[str, Any]
+        item: Dict[str, Any],
+        keys: List[str],
+        parent: Dict[str, Any],
+        *,
+        canonical_role: Optional[str] = None,
+        alias_roles: Optional[List[str]] = None,
     ) -> Optional[Dict[str, List[str]]]:
         """Collect respostas keyed by role with names appended."""
 
         coletadas: Dict[str, List[str]] = {}
         respostas = item.get("respostas")
+        alias_set = set(alias_roles or [])
+        if canonical_role:
+            alias_set.add(canonical_role)
+
+        def _store(target: str, valores: List[str]) -> None:
+            if target in coletadas:
+                merged = _merge_respostas({target: coletadas[target]}, {target: valores})
+                coletadas[target] = merged.get(target, valores)
+            else:
+                coletadas[target] = valores
+
         if isinstance(respostas, dict):
             for papel in keys:
                 valores = respostas.get(papel)
                 if isinstance(valores, list):
                     lista = list(valores)
+                    target = (
+                        canonical_role
+                        if canonical_role and papel in alias_set
+                        else papel
+                    )
                     nome = item.get(papel) or parent.get(papel)
+                    if canonical_role and target == canonical_role and not nome:
+                        nome = item.get(canonical_role) or parent.get(canonical_role)
                     if nome and nome not in lista[1:]:
                         if lista:
                             lista.append(nome)
                         else:
                             lista = [nome]
-                    coletadas[papel] = lista
+                    _store(target, lista)
         elif isinstance(respostas, list):
             for resp in respostas:
                 if (
@@ -102,24 +151,36 @@ def merge_checklists(json_suprimento: Dict[str, Any], json_producao: Dict[str, A
                     and resp.get("papel")
                 ):
                     papel = resp["papel"]
+                    target = (
+                        canonical_role
+                        if canonical_role and papel in alias_set
+                        else papel
+                    )
                     lista = [resp["valor"]]
                     nome = resp.get("nome")
                     if nome:
                         lista.append(nome)
-                    coletadas[papel] = lista
+                    _store(target, lista)
 
         if not coletadas:
             resposta = item.get("resposta")
             if isinstance(resposta, list):
                 papel = keys[0] if keys else "resposta"
+                target = (
+                    canonical_role
+                    if canonical_role and papel in alias_set
+                    else papel
+                )
                 lista = list(resposta)
                 nome = parent.get(papel)
+                if canonical_role and target == canonical_role and not nome:
+                    nome = parent.get(canonical_role)
                 if nome:
                     if lista:
                         lista.append(nome)
                     else:
                         lista = [nome]
-                coletadas[papel] = lista
+                coletadas[target] = lista
         return coletadas or None
 
     for item in json_suprimento.get("itens", []):
@@ -128,11 +189,17 @@ def merge_checklists(json_suprimento: Dict[str, Any], json_producao: Dict[str, A
             continue
         pergunta = item.get("pergunta", "")
         resposta = _extract_respostas(
-            item, ["suprimento", "produção", "producao"], json_suprimento
+            item,
+            ["suprimento", "produção", "producao"],
+            json_suprimento,
+            canonical_role="suprimento",
+            alias_roles=["suprimento", "produção", "producao"],
         )
-        itens.setdefault(numero, {})["pergunta_sup"] = pergunta
-        itens[numero]["res_sup"] = resposta
-        itens_por_pergunta.setdefault(pergunta, []).append(numero)
+        bucket = _bucket_for(pergunta)
+        if numero is not None:
+            bucket["numeros"].add(numero)
+        _update_pergunta(bucket, "pergunta_sup", pergunta)
+        bucket["res_sup"] = _merge_dict(bucket.get("res_sup"), resposta)
     for item in json_producao.get("itens", []):
         numero = item.get("numero")
         if numero is None:
@@ -143,43 +210,67 @@ def merge_checklists(json_suprimento: Dict[str, Any], json_producao: Dict[str, A
             ["montador", "produção", "producao", "suprimento"],
             json_producao,
         )
-        entry = itens.setdefault(numero, {})
-        entry["pergunta_prod"] = pergunta
-        entry["res_prod"] = resposta
-        itens_por_pergunta.setdefault(pergunta, []).append(numero)
+        bucket = _bucket_for(pergunta)
+        if numero is not None:
+            bucket["numeros"].add(numero)
+        _update_pergunta(bucket, "pergunta_prod", pergunta)
+        bucket["res_prod"] = _merge_dict(bucket.get("res_prod"), resposta)
         
         
-    def _merge_dict(
-        a: Optional[Dict[str, List[str]]], b: Optional[Dict[str, List[str]]]
-    ) -> Optional[Dict[str, List[str]]]:
-        return _merge_respostas(a, b)
-
     result_items: List[Dict[str, Any]] = []
-    for pergunta, numeros in itens_por_pergunta.items():
-        nums = sorted({n for n in numeros if n is not None})
-        pergunta_final = pergunta
-        res_sup: Optional[Dict[str, List[str]]] = None
-        res_prod: Optional[Dict[str, List[str]]] = None
-        for numero in nums:
-            entry = itens.get(numero, {})
-            pergunta_sup = entry.get("pergunta_sup", "")
-            pergunta_prod = entry.get("pergunta_prod", "")
-            if len(pergunta_sup) > len(pergunta_final):
-                pergunta_final = pergunta_sup
-            if len(pergunta_prod) > len(pergunta_final):
-                pergunta_final = pergunta_prod
-            res_sup = _merge_dict(res_sup, entry.get("res_sup"))
-            res_prod = _merge_dict(res_prod, entry.get("res_prod"))
-
+    for pergunta, dados in buckets.items():
+        numeros = sorted(dados.get("numeros", set()))
+        res_sup = dados.get("res_sup")
+        res_prod = dados.get("res_prod")
         res_unificado = _merge_dict(res_sup, res_prod)
+        pergunta_final = dados.get("pergunta_final") or pergunta
         result_items.append(
             {
-                "numero": nums,
+                "numero": numeros,
                 "pergunta": pergunta_final,
                 "respostas": res_unificado,
             }
         )
-    result["itens"] = sorted(result_items, key=lambda x: x["numero"][0] if x.get("numero") else 0)
+    result["itens"] = sorted(
+        result_items, key=lambda x: x["numero"][0] if x.get("numero") else 0
+    )
+
+    def _first_from_items(data: Dict[str, Any], roles: List[str]) -> Optional[str]:
+        for item in data.get("itens", []):
+            for role in roles:
+                nome = item.get(role)
+                if isinstance(nome, str) and nome.strip():
+                    return nome.strip()
+            respostas = item.get("respostas")
+            if isinstance(respostas, dict):
+                for role in roles:
+                    valores = respostas.get(role)
+                    if isinstance(valores, list):
+                        for candidato in valores[1:]:
+                            if isinstance(candidato, str) and candidato.strip():
+                                return candidato.strip()
+            elif isinstance(respostas, list):
+                for resp in respostas:
+                    if (
+                        isinstance(resp, dict)
+                        and resp.get("papel") in roles
+                        and isinstance(resp.get("nome"), str)
+                        and resp["nome"].strip()
+                    ):
+                        return resp["nome"].strip()
+        return None
+
+    if not result["respondentes"].get("suprimento"):
+        nome = _first_from_items(json_suprimento, ["suprimento", "produção", "producao"])
+        if nome:
+            result["respondentes"]["suprimento"] = nome
+
+    if not result["respondentes"].get("produção"):
+        nome = _first_from_items(
+            json_producao, ["montador", "produção", "producao", "suprimento"]
+        )
+        if nome:
+            result["respondentes"]["produção"] = nome
 
     materiais: Dict[str, Dict[str, Any]] = {}
     for mat in json_suprimento.get("materiais", []) + json_producao.get("materiais", []):
@@ -292,6 +383,9 @@ def merge_directory(base_dir: str, output_dir: Optional[str] = None) -> List[Dic
 
         def _is_production(entry: Dict[str, Any]) -> bool:
             data = entry["data"]
+            origem = str(data.get("origem", "")).strip().lower()
+            if origem == "appoficina":
+                return True
             if any(k in data for k in ("produção", "producao", "montador")):
                 return True
             for item in data.get("itens", []) or []:

--- a/tests/test_merge_checklists.py
+++ b/tests/test_merge_checklists.py
@@ -50,7 +50,7 @@ def test_merge_checklists_accepts_montador_key() -> None:
     sup = {
         "obra": "OBRA1",
         "ano": "2024",
-        "suprimento": "Carlos",
+        "suprimento": "Victor",
         "itens": [
             {
                 "numero": 1,
@@ -79,7 +79,7 @@ def test_merge_checklists_handles_multiple_montadores() -> None:
     sup = {
         "obra": "OBRA1",
         "ano": "2024",
-        "suprimento": "Carlos",
+        "suprimento": "Victor",
         "itens": [
             {
                 "numero": 1,
@@ -110,8 +110,98 @@ def test_merge_checklists_handles_multiple_montadores() -> None:
     merged = merge.merge_checklists(sup, prod)
     assert merged["respondentes"]["produção"] == "Joao"
     assert merged["itens"][0]["respostas"] == {
-        "suprimento": ["C", "Carlos"],
+        "suprimento": ["C", "Victor"],
         "montador": ["C", "Joao"],
+    }
+
+
+def test_merge_checklists_handles_conflicting_numbers_and_missing_montador() -> None:
+    sup = {
+        "obra": "OBRA1",
+        "ano": "2024",
+        "suprimento": "Victor",
+        "itens": [
+            {
+                "numero": 1,
+                "pergunta": "Pergunta A",
+                "respostas": {"suprimento": ["C"]},
+            },
+            {
+                "numero": 75,
+                "pergunta": "Pergunta B",
+                "respostas": {"suprimento": ["C"]},
+            },
+        ],
+    }
+    prod = {
+        "obra": "OBRA1",
+        "ano": "2024",
+        "origem": "AppOficina",
+        "itens": [
+            {
+                "numero": 55,
+                "pergunta": "Pergunta A",
+                "respostas": {"producao": ["C", "Carlos"]},
+            },
+            {
+                "numero": 75,
+                "pergunta": "Pergunta C",
+                "respostas": {"producao": ["C", "Carlos"]},
+            },
+            {
+                "numero": 109,
+                "pergunta": "Pergunta B",
+                "respostas": {"producao": ["C", "Carlos"]},
+            },
+        ],
+    }
+
+    merged = merge.merge_checklists(sup, prod)
+
+    perguntas = {item["pergunta"]: item for item in merged["itens"]}
+    assert perguntas["Pergunta B"]["numero"] == [75, 109]
+    assert perguntas["Pergunta B"]["respostas"] == {
+        "suprimento": ["C", "Victor"],
+        "producao": ["C", "Carlos"],
+    }
+    assert perguntas["Pergunta C"]["numero"] == [75]
+    assert merged["respondentes"]["produção"] == "Carlos"
+
+
+def test_merge_checklists_maps_appestoque_aliases_to_suprimento() -> None:
+    pergunta = "1.15 - COMPONENTES: Identificação do projeto"
+    sup = {
+        "obra": "MERGEKRAI",
+        "ano": "2025",
+        "suprimento": "victorr",
+        "itens": [
+            {
+                "numero": 75,
+                "pergunta": pergunta,
+                "respostas": {"producao": ["C"]},
+            }
+        ],
+    }
+    prod = {
+        "obra": "MERGEKRAI",
+        "ano": "2025",
+        "origem": "AppOficina",
+        "itens": [
+            {
+                "numero": 109,
+                "pergunta": pergunta,
+                "respostas": {"producao": ["C", "Carlos"]},
+            }
+        ],
+    }
+
+    merged = merge.merge_checklists(sup, prod)
+
+    item = next(entry for entry in merged["itens"] if entry["pergunta"] == pergunta)
+    assert item["numero"] == [75, 109]
+    assert item["respostas"] == {
+        "suprimento": ["C", "victorr"],
+        "producao": ["C", "Carlos"],
     }
 
 
@@ -216,6 +306,54 @@ def test_merge_directory_detects_production_in_item_respostas(tmp_path: pathlib.
         "suprimento": ["C", "Carlos"],
         "montador": ["J"],
     }
+
+
+def test_merge_directory_handles_appoficina_origin(tmp_path: pathlib.Path) -> None:
+    sup = {
+        "obra": "OBRA1",
+        "ano": "2024",
+        "suprimento": "Carlos",
+        "itens": [
+            {
+                "numero": 1,
+                "pergunta": "Pergunta",
+                "respostas": {"suprimento": ["C"]},
+            }
+        ],
+    }
+    prod = {
+        "obra": "OBRA1",
+        "ano": "2024",
+        "origem": "AppOficina",
+        "itens": [
+            {
+                "numero": 1,
+                "pergunta": "Pergunta",
+                "resposta": ["OK"],
+            }
+        ],
+    }
+
+    sup_path = tmp_path / "sup_OBRA1.json"
+    prod_path = tmp_path / "20240102T120000_OBRA1.json"
+    with open(sup_path, "w", encoding="utf-8") as fp:
+        json.dump(sup, fp, ensure_ascii=False)
+    with open(prod_path, "w", encoding="utf-8") as fp:
+        json.dump(prod, fp, ensure_ascii=False)
+
+    merged = merge.merge_directory(str(tmp_path))
+    assert len(merged) == 1
+
+    out_path = tmp_path / "Posto01_Oficina" / "checklist_OBRA1.json"
+    with open(out_path, "r", encoding="utf-8") as fp:
+        data = json.load(fp)
+
+    assert data["itens"][0]["respostas"] == {
+        "suprimento": ["C", "Carlos"],
+        "montador": ["OK"],
+    }
+    assert not sup_path.exists()
+    assert not prod_path.exists()
 
 def test_posto02_inspector_allows_extra_annotations(tmp_path: pathlib.Path) -> None:
     api.BASE_DIR = str(tmp_path)


### PR DESCRIPTION
## Summary
- normalize the resposta collector to support canonical roles and map AppEstoque aliases to `suprimento` so late questions keep the supply answers
- treat supply pulls with canonical metadata when extracting responses to preserve respondent names during the merge
- add a regression test covering AppEstoque items that report only `producao` for supply questions to ensure the merged checklist carries both roles

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68caa21f0260832f87f764acfb017216