### PR TITLE
Correct Projetista labeling and produção header in checklist PDF

### DIFF
--- a/site/projetista/templates/checklist_view.html
+++ b/site/projetista/templates/checklist_view.html
@@ -17,9 +17,9 @@
 function gerarPDF(base){
     const cidade=prompt('Cidade/Estado:');
     if(cidade===null) return;
-    const projesta=prompt('Projesta:');
-    if(projesta===null) return;
-    window.location.href = base + '?cidade_estado=' + encodeURIComponent(cidade) + '&projesta=' + encodeURIComponent(projesta);
+    const projetista=prompt('Projetista:');
+    if(projetista===null) return;
+    window.location.href = base + '?cidade_estado=' + encodeURIComponent(cidade) + '&projesta=' + encodeURIComponent(projetista);
 }
 </script>
 

--- a/site/templates/checklist.html
+++ b/site/templates/checklist.html
@@ -85,11 +85,11 @@ function generatePDF(){
     }
     const cidade = prompt('Cidade/Estado:');
     if(cidade===null) return;
-    const projesta = prompt('Projesta:');
-    if(projesta===null) return;
+    const projetista = prompt('Projetista:');
+    if(projetista===null) return;
     const path = encodeURIComponent(currentFolder) + '/' + encodeURIComponent(currentFileName);
     const base = "{{ url_for('projetista.checklist_pdf', filename='') }}" + path;
-    const url = base + `?cidade_estado=${encodeURIComponent(cidade)}&projesta=${encodeURIComponent(projesta)}`;
+    const url = base + `?cidade_estado=${encodeURIComponent(cidade)}&projesta=${encodeURIComponent(projetista)}`;
     window.location.href = url;
 }
 


### PR DESCRIPTION
## Summary
- accept Projetista input and display the label correctly in the checklist PDF
- map production role headers so the PDF always shows "Produção"
- update Projetista prompts in the web UI before generating PDFs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbf1d93a30832fbb666a9865d8a134