### PR TITLE
Atualiza opções N.A nos checklists do posto 08

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto08IqeActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto08IqeActivity.kt
@@ -45,7 +45,7 @@ class ChecklistPosto08IqeActivity : AppCompatActivity() {
             val c = CheckBox(this)
             c.text = "C"
             val nc = CheckBox(this)
-            nc.text = "N.C"
+            nc.text = "N.A"
             nc.setPadding(24, 0, 0, 0)
             row.addView(c)
             row.addView(nc)
@@ -100,7 +100,7 @@ class ChecklistPosto08IqeActivity : AppCompatActivity() {
             obj.put("numero", 8201 + idx)
             obj.put("pergunta", perguntas[idx])
             val resp = JSONArray()
-            resp.put(if (c.isChecked) "C" else "NC")
+            resp.put(if (c.isChecked) "C" else "NA")
             obj.put("resposta", resp)
             itens.put(obj)
         }

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto08IqmActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto08IqmActivity.kt
@@ -51,7 +51,7 @@ class ChecklistPosto08IqmActivity : AppCompatActivity() {
             val c = CheckBox(this)
             c.text = "C"
             val nc = CheckBox(this)
-            nc.text = "N.C"
+            nc.text = "N.A"
             nc.setPadding(24, 0, 0, 0)
             row.addView(c)
             row.addView(nc)
@@ -87,7 +87,7 @@ class ChecklistPosto08IqmActivity : AppCompatActivity() {
                     obj.put("pergunta", perguntas[idx])
                     val respostas = JSONObject()
                     val arr = JSONArray()
-                    arr.put(if (c.isChecked) "C" else "NC")
+                    arr.put(if (c.isChecked) "C" else "NA")
                     respostas.put("inspetor", arr)
                     obj.put("respostas", respostas)
                     itens.put(obj)

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto08TesteActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto08TesteActivity.kt
@@ -213,7 +213,7 @@ class ChecklistPosto08TesteActivity : AppCompatActivity() {
             val c = CheckBox(this)
             c.text = "C"
             val na = CheckBox(this)
-            na.text = "NA"
+            na.text = "N.A"
             na.setPadding(24, 0, 0, 0)
             row.addView(c)
             row.addView(na)
@@ -242,7 +242,7 @@ class ChecklistPosto08TesteActivity : AppCompatActivity() {
             val c = CheckBox(this)
             c.text = "C"
             val na = CheckBox(this)
-            na.text = "NA"
+            na.text = "N.A"
             na.setPadding(24, 0, 0, 0)
             row.addView(c)
             row.addView(na)


### PR DESCRIPTION
## Summary
- substitui o rótulo de resposta N.C por N.A nas telas de checklist IQM e IQE do posto 08
- ajusta os payloads enviados para registrar NA quando a opção não aplicável é selecionada nesses checklists
- atualiza os rótulos das opções não aplicáveis nas seções de configuração e funcionais do checklist de teste do posto 08

## Testing
- não executado (não solicitado)


------
https://chatgpt.com/codex/tasks/task_e_68cc2961a844832f92ecab4de23194d5