### PR TITLE
Add checklist preview for Posto01 materials

### DIFF
--- a/tests/test_checklist_origin.py
+++ b/tests/test_checklist_origin.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
 import pathlib
+import time
 from flask import Flask
 
 import importlib
@@ -87,3 +89,63 @@ def test_salvar_checklist_multiple_uploads_unique_names(tmp_path: pathlib.Path, 
 
     assert called["merge"] == 1
     assert called["move"] == 1
+
+
+def test_obter_checklist_requires_obra(tmp_path: pathlib.Path):
+    client = _client(tmp_path)
+
+    res = client.get("/checklist")
+    assert res.status_code == 400
+    assert res.get_json()["erro"] == "obra obrigatória"
+
+
+def test_obter_checklist_inexistente(tmp_path: pathlib.Path):
+    client = _client(tmp_path)
+
+    res = client.get("/checklist", query_string={"obra": "OBRA-XYZ"})
+    assert res.status_code == 404
+
+
+def test_obter_checklist_retorna_arquivo_mais_recente(tmp_path: pathlib.Path):
+    client = _client(tmp_path)
+
+    antigo = tmp_path / "checklist_OBRA1_20220101.json"
+    antigo.write_text(
+        json.dumps(
+            {
+                "obra": "OBRA1",
+                "itens": [
+                    {"pergunta": "Antiga", "respostas": {"suprimento": ["NC"]}},
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    timestamp_antigo = time.time() - 3600
+    os.utime(antigo, (timestamp_antigo, timestamp_antigo))
+
+    destino = tmp_path / "Posto01_Oficina"
+    destino.mkdir()
+    recente = destino / "checklist_OBRA1.json"
+    recente.write_text(
+        json.dumps(
+            {
+                "obra": "OBRA1",
+                "itens": [
+                    {
+                        "pergunta": "Atual",
+                        "respostas": {"suprimento": ["C", "Maria"]},
+                    },
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    res = client.get("/checklist", query_string={"obra": "OBRA1"})
+    assert res.status_code == 200
+    dados = res.get_json()
+    assert dados["checklist"]["itens"][0]["pergunta"] == "Atual"
+    assert dados["checklist"]["itens"][0]["respostas"]["suprimento"][0] == "C"

--- a/tests/test_merge_checklists.py
+++ b/tests/test_merge_checklists.py
@@ -291,6 +291,40 @@ def test_move_matching_preserves_extra_annotations(tmp_path: pathlib.Path) -> No
     assert find_mismatches(str(tmp_path / "Posto02_Oficina")) == []
 
 
+def test_move_matching_removes_raw_uploads(tmp_path: pathlib.Path) -> None:
+    src_dir = tmp_path / "Posto01_Oficina"
+    src_dir.mkdir()
+
+    checklist_path = src_dir / "checklist_OBRA1.json"
+    data = {
+        "obra": "OBRA1",
+        "ano": "2024",
+        "itens": [
+            {
+                "numero": 1,
+                "pergunta": "Pergunta",
+                "respostas": {"suprimento": ["C"], "produção": ["C"]},
+            }
+        ],
+    }
+    with open(checklist_path, "w", encoding="utf-8") as fp:
+        json.dump(data, fp, ensure_ascii=False)
+
+    leftover = tmp_path / "checklist_OBRA1_20240101000000.json"
+    with open(leftover, "w", encoding="utf-8") as fp:
+        json.dump({"obra": "OBRA1", "itens": []}, fp, ensure_ascii=False)
+
+    other = tmp_path / "checklist_OBRA2_20240101000000.json"
+    with open(other, "w", encoding="utf-8") as fp:
+        json.dump({"obra": "OBRA2", "itens": []}, fp, ensure_ascii=False)
+
+    moved = move_matching_checklists(str(tmp_path))
+    assert moved == ["checklist_OBRA1.json"]
+
+    assert not leftover.exists()
+    assert other.exists()
+
+
 def test_cli_merges_and_moves_to_posto02(tmp_path: pathlib.Path) -> None:
     sup = {
         "obra": "OBRA1",


### PR DESCRIPTION
## Summary
- expose a GET /json_api/checklist endpoint that returns the latest checklist JSON for an obra
- show a floating pre-visualization dialog in the Posto 01 Materiais checklist using the fetched data
- cover the new API behaviour with unit tests to ensure correct responses

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd5af5b110832f8413908196893639