### PR TITLE
Corrigir pré-visualização flutuante no checklist do posto 01 parte 2

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto01Parte2Activity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto01Parte2Activity.kt
@@ -18,7 +18,6 @@ import org.json.JSONObject
 import java.io.OutputStreamWriter
 import java.net.HttpURLConnection
 import java.net.URL
-import java.util.Locale
 
 class ChecklistPosto01Parte2Activity : AppCompatActivity() {
     private lateinit var previewHelper: FloatingChecklistPreview
@@ -145,45 +144,8 @@ class ChecklistPosto01Parte2Activity : AppCompatActivity() {
             findViewById<ScrollView>(R.id.preview_scroll),
             findViewById(R.id.preview_header),
             findViewById<ImageButton>(R.id.preview_close_button),
- 
-        previewContainer = findViewById(R.id.preview_container)
-        previewContent = findViewById(R.id.preview_content)
-        previewScroll = findViewById(R.id.preview_scroll)
-
-        val previewHeader = findViewById<View>(R.id.preview_header)
-        val previewCloseButton = findViewById<ImageButton>(R.id.preview_close_button)
-
-        previewCloseButton.setOnClickListener {
-            previewContainer.visibility = View.GONE
-        }
-
-        var dragOffsetX = 0f
-        var dragOffsetY = 0f
-        previewHeader.setOnTouchListener { _, event ->
-            when (event.actionMasked) {
-                MotionEvent.ACTION_DOWN -> {
-                    dragOffsetX = previewContainer.x - event.rawX
-                    dragOffsetY = previewContainer.y - event.rawY
-                    true
-                }
-                MotionEvent.ACTION_MOVE -> {
-                    val parent = previewContainer.parent
-                    if (parent is View && parent.width > 0 && parent.height > 0) {
-                        val maxX = (parent.width - previewContainer.width).coerceAtLeast(0)
-                        val maxY = (parent.height - previewContainer.height).coerceAtLeast(0)
-                        val newX = (event.rawX + dragOffsetX).coerceIn(0f, maxX.toFloat())
-                        val newY = (event.rawY + dragOffsetY).coerceIn(0f, maxY.toFloat())
-                        previewContainer.x = newX
-                        previewContainer.y = newY
-                        true
-                    } else {
-                        false
-                    }
-                }
-                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> true
-                else -> false
-            }
-        }
+            findViewById<ImageButton>(R.id.preview_toggle_button),
+        )
 
         fun updateButtonState() {
             concluirButton.isEnabled = triplets.all { (c, nc, na) ->

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02InspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02InspActivity.kt
@@ -33,6 +33,7 @@ class ChecklistPosto02InspActivity : AppCompatActivity() {
             findViewById<ScrollView>(R.id.preview_scroll),
             findViewById(R.id.preview_header),
             findViewById<ImageButton>(R.id.preview_close_button),
+            findViewById<ImageButton>(R.id.preview_toggle_button),
         )
         previewHelper.loadPreviousChecklist(obra, ano)
 

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto03PreInspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto03PreInspActivity.kt
@@ -32,6 +32,7 @@ class ChecklistPosto03PreInspActivity : AppCompatActivity() {
             findViewById<ScrollView>(R.id.preview_scroll),
             findViewById(R.id.preview_header),
             findViewById<ImageButton>(R.id.preview_close_button),
+            findViewById<ImageButton>(R.id.preview_toggle_button),
         )
         previewHelper.loadPreviousChecklist(obra, ano)
 

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto04BarramentoInspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto04BarramentoInspActivity.kt
@@ -32,6 +32,7 @@ class ChecklistPosto04BarramentoInspActivity : AppCompatActivity() {
             findViewById<ScrollView>(R.id.preview_scroll),
             findViewById(R.id.preview_header),
             findViewById<ImageButton>(R.id.preview_close_button),
+            findViewById<ImageButton>(R.id.preview_toggle_button),
         )
         previewHelper.loadPreviousChecklist(obra, ano)
 

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto05CablagemInspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto05CablagemInspActivity.kt
@@ -32,6 +32,7 @@ class ChecklistPosto05CablagemInspActivity : AppCompatActivity() {
             findViewById<ScrollView>(R.id.preview_scroll),
             findViewById(R.id.preview_header),
             findViewById<ImageButton>(R.id.preview_close_button),
+            findViewById<ImageButton>(R.id.preview_toggle_button),
         )
         previewHelper.loadPreviousChecklist(obra, ano)
 

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto06Cablagem02InspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto06Cablagem02InspActivity.kt
@@ -32,6 +32,7 @@ class ChecklistPosto06Cablagem02InspActivity : AppCompatActivity() {
             findViewById<ScrollView>(R.id.preview_scroll),
             findViewById(R.id.preview_header),
             findViewById<ImageButton>(R.id.preview_close_button),
+            findViewById<ImageButton>(R.id.preview_toggle_button),
         )
         previewHelper.loadPreviousChecklist(obra, ano)
 

--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto06PreInspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto06PreInspActivity.kt
@@ -32,6 +32,7 @@ class ChecklistPosto06PreInspActivity : AppCompatActivity() {
             findViewById<ScrollView>(R.id.preview_scroll),
             findViewById(R.id.preview_header),
             findViewById<ImageButton>(R.id.preview_close_button),
+            findViewById<ImageButton>(R.id.preview_toggle_button),
         )
         previewHelper.loadPreviousChecklist(obra, ano)
 

--- a/AppOficina/app/src/main/res/drawable/bg_preview_toggle.xml
+++ b/AppOficina/app/src/main/res/drawable/bg_preview_toggle.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@android:color/white" />
+    <stroke
+        android:width="1dp"
+        android:color="#19000000" />
+    <size
+        android:width="48dp"
+        android:height="48dp" />
+    <padding
+        android:bottom="4dp"
+        android:left="4dp"
+        android:right="4dp"
+        android:top="4dp" />
+</shape>

--- a/AppOficina/app/src/main/res/layout/activity_checklist_posto01_parte2.xml
+++ b/AppOficina/app/src/main/res/layout/activity_checklist_posto01_parte2.xml
@@ -85,4 +85,18 @@
         </ScrollView>
     </LinearLayout>
 
+    <ImageButton
+        android:id="@+id/preview_toggle_button"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="end|bottom"
+        android:layout_margin="16dp"
+        android:background="@drawable/bg_preview_toggle"
+        android:contentDescription="@string/show_previous_checklist"
+        android:elevation="8dp"
+        android:padding="12dp"
+        android:src="@android:drawable/ic_menu_view"
+        android:tint="?android:attr/textColorPrimary"
+        android:visibility="gone" />
+
 </FrameLayout>

--- a/AppOficina/app/src/main/res/layout/activity_checklist_posto02.xml
+++ b/AppOficina/app/src/main/res/layout/activity_checklist_posto02.xml
@@ -93,4 +93,18 @@
         </ScrollView>
     </LinearLayout>
 
+    <ImageButton
+        android:id="@+id/preview_toggle_button"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="end|bottom"
+        android:layout_margin="16dp"
+        android:background="@drawable/bg_preview_toggle"
+        android:contentDescription="@string/show_previous_checklist"
+        android:elevation="8dp"
+        android:padding="12dp"
+        android:src="@android:drawable/ic_menu_view"
+        android:tint="?android:attr/textColorPrimary"
+        android:visibility="gone" />
+
 </FrameLayout>

--- a/AppOficina/app/src/main/res/layout/activity_checklist_posto03_pre_montagem_01.xml
+++ b/AppOficina/app/src/main/res/layout/activity_checklist_posto03_pre_montagem_01.xml
@@ -93,4 +93,18 @@
         </ScrollView>
     </LinearLayout>
 
+    <ImageButton
+        android:id="@+id/preview_toggle_button"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="end|bottom"
+        android:layout_margin="16dp"
+        android:background="@drawable/bg_preview_toggle"
+        android:contentDescription="@string/show_previous_checklist"
+        android:elevation="8dp"
+        android:padding="12dp"
+        android:src="@android:drawable/ic_menu_view"
+        android:tint="?android:attr/textColorPrimary"
+        android:visibility="gone" />
+
 </FrameLayout>

--- a/AppOficina/app/src/main/res/layout/activity_checklist_posto04_barramento.xml
+++ b/AppOficina/app/src/main/res/layout/activity_checklist_posto04_barramento.xml
@@ -93,4 +93,18 @@
         </ScrollView>
     </LinearLayout>
 
+    <ImageButton
+        android:id="@+id/preview_toggle_button"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="end|bottom"
+        android:layout_margin="16dp"
+        android:background="@drawable/bg_preview_toggle"
+        android:contentDescription="@string/show_previous_checklist"
+        android:elevation="8dp"
+        android:padding="12dp"
+        android:src="@android:drawable/ic_menu_view"
+        android:tint="?android:attr/textColorPrimary"
+        android:visibility="gone" />
+
 </FrameLayout>

--- a/AppOficina/app/src/main/res/layout/activity_checklist_posto05_cablagem.xml
+++ b/AppOficina/app/src/main/res/layout/activity_checklist_posto05_cablagem.xml
@@ -93,4 +93,18 @@
         </ScrollView>
     </LinearLayout>
 
+    <ImageButton
+        android:id="@+id/preview_toggle_button"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="end|bottom"
+        android:layout_margin="16dp"
+        android:background="@drawable/bg_preview_toggle"
+        android:contentDescription="@string/show_previous_checklist"
+        android:elevation="8dp"
+        android:padding="12dp"
+        android:src="@android:drawable/ic_menu_view"
+        android:tint="?android:attr/textColorPrimary"
+        android:visibility="gone" />
+
 </FrameLayout>

--- a/AppOficina/app/src/main/res/layout/activity_checklist_posto06_cablagem_02.xml
+++ b/AppOficina/app/src/main/res/layout/activity_checklist_posto06_cablagem_02.xml
@@ -93,4 +93,18 @@
         </ScrollView>
     </LinearLayout>
 
+    <ImageButton
+        android:id="@+id/preview_toggle_button"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="end|bottom"
+        android:layout_margin="16dp"
+        android:background="@drawable/bg_preview_toggle"
+        android:contentDescription="@string/show_previous_checklist"
+        android:elevation="8dp"
+        android:padding="12dp"
+        android:src="@android:drawable/ic_menu_view"
+        android:tint="?android:attr/textColorPrimary"
+        android:visibility="gone" />
+
 </FrameLayout>

--- a/AppOficina/app/src/main/res/layout/activity_checklist_posto06_pre_montagem_02.xml
+++ b/AppOficina/app/src/main/res/layout/activity_checklist_posto06_pre_montagem_02.xml
@@ -93,4 +93,18 @@
         </ScrollView>
     </LinearLayout>
 
+    <ImageButton
+        android:id="@+id/preview_toggle_button"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="end|bottom"
+        android:layout_margin="16dp"
+        android:background="@drawable/bg_preview_toggle"
+        android:contentDescription="@string/show_previous_checklist"
+        android:elevation="8dp"
+        android:padding="12dp"
+        android:src="@android:drawable/ic_menu_view"
+        android:tint="?android:attr/textColorPrimary"
+        android:visibility="gone" />
+
 </FrameLayout>

--- a/AppOficina/app/src/main/res/values/strings.xml
+++ b/AppOficina/app/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <resources>
     <string name="app_name">Oficina</string>
     <string name="inspetor">Inspetor</string>
+    <string name="show_previous_checklist">Mostrar pré-visualização anterior</string>
+    <string name="hide_previous_checklist">Ocultar pré-visualização anterior</string>
 </resources>


### PR DESCRIPTION
## Summary
- reutiliza o helper de pré-visualização no checklist do posto 01 parte 2
- adiciona o botão flutuante de reabertura na tela para manter o checklist anterior acessível
- remove uma importação obsoleta após a limpeza do código legado

## Testing
- `bash gradlew --no-daemon assembleDebug --console=plain` *(falha: SDK Android ausente no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68d19b9dfbb4832fb2ff964c39a7c764