### PR TITLE
Add previous checklist preview to posto 02 montador

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02Activity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02Activity.kt
@@ -22,6 +22,18 @@ class ChecklistPosto02Activity : AppCompatActivity() {
             .getString("montadores", "") ?: ""
         val montadoresList = montadoresPrefs.split("\n").filter { it.isNotBlank() }
 
+        val previewHelper = FloatingChecklistPreview(
+            this,
+            findViewById(R.id.preview_container),
+            findViewById<LinearLayout>(R.id.preview_content),
+            findViewById<ScrollView>(R.id.preview_scroll),
+            findViewById(R.id.preview_header),
+            findViewById<ImageButton>(R.id.preview_close_button),
+            findViewById<ImageButton>(R.id.preview_toggle_button),
+            sectionKey = "posto02",
+        )
+        previewHelper.loadPreviousChecklist(obra, ano)
+
         val perguntas = listOf(
             "2.1 - PORTAS: Identificação do projeto",
             "2.1 - PORTAS: Marcação",


### PR DESCRIPTION
## Summary
- instantiate the FloatingChecklistPreview in ChecklistPosto02Activity
- allow posto 02 montador workflow to load and toggle the previous checklist panel like the other screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2c72d5d24832f935c4b7d52fc7053