### PR TITLE
Adjust posto02 checklist preview handling

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/FloatingChecklistPreview.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/FloatingChecklistPreview.kt
@@ -92,8 +92,16 @@ class FloatingChecklistPreview(
                 return@Thread
             }
 
+            val isPosto02 = sectionKey?.equals("posto02", ignoreCase = true) == true
             val endereco = try {
-                val builder = StringBuilder("http://$ip:5000/json_api/checklist?obra=")
+                val path = if (isPosto02) {
+                    "/json_api/posto02/checklist"
+                } else {
+                    "/json_api/checklist"
+                }
+                val builder = StringBuilder("http://$ip:5000")
+                builder.append(path)
+                builder.append("?obra=")
                 builder.append(URLEncoder.encode(obra, "UTF-8"))
                 if (!ano.isNullOrBlank()) {
                     builder.append("&ano=")
@@ -114,9 +122,9 @@ class FloatingChecklistPreview(
                 if (codigo in 200..299) {
                     val resposta = conn.inputStream.bufferedReader().use { it.readText() }
                     val json = JSONObject(resposta)
-                    val checklist = json.optJSONObject("checklist")
-                    if (checklist != null) {
-                        activity.runOnUiThread { mostrarChecklist(checklist) }
+                    val checklist = if (isPosto02) json else json.optJSONObject("checklist")
+                    if (checklist != null || isPosto02) {
+                        activity.runOnUiThread { mostrarChecklist(checklist ?: json) }
                     }
                 }
                 conn.disconnect()


### PR DESCRIPTION
## Summary
- fetch posto 02 previews from the dedicated checklist endpoint
- treat posto 02 responses as the checklist payload so the renderer can show items

## Testing
- ./gradlew lint *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2cf6cff0c832fbeb5cf71cd80e275