### PR TITLE
Fix checklist preview payload merging and prefill posto02 responses

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/FloatingChecklistPreview.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/FloatingChecklistPreview.kt
@@ -122,13 +122,18 @@ class FloatingChecklistPreview(
                 if (codigo in 200..299) {
                     val resposta = conn.inputStream.bufferedReader().use { it.readText() }
                     val json = JSONObject(resposta)
-                    val checklist = if (isPosto02) {
+                    val embeddedChecklist = if (isPosto02) {
                         json.optJSONObject("checklist") ?: json
                     } else {
                         json.optJSONObject("checklist")
                     }
-                    if (checklist != null) {
-                        activity.runOnUiThread { mostrarChecklist(checklist) }
+                    val displayChecklist = when {
+                        embeddedChecklist == null -> json
+                        embeddedChecklist === json -> json
+                        else -> mergeChecklistPayload(embeddedChecklist, json)
+                    }
+                    activity.runOnUiThread {
+                        mostrarChecklist(displayChecklist)
                     }
                 }
                 conn.disconnect()
@@ -137,6 +142,65 @@ class FloatingChecklistPreview(
                 fetchInProgress = false
             }
         }.start()
+    }
+
+    private fun mergeChecklistPayload(primary: JSONObject, original: JSONObject): JSONObject {
+        val merged = JSONObject(primary.toString())
+
+        fun copyPrimitive(key: String) {
+            if (!merged.has(key)) {
+                val value = original.opt(key)
+                if (value != null && value != JSONObject.NULL) {
+                    merged.put(key, value)
+                }
+            }
+        }
+
+        copyPrimitive("obra")
+        copyPrimitive("ano")
+
+        if (!merged.has("respondentes")) {
+            original.optJSONObject("respondentes")?.let { merged.put("respondentes", it) }
+        }
+
+        if (!merged.has("itens")) {
+            original.optJSONArray("itens")?.let { merged.put("itens", it) }
+        }
+
+        sectionKey?.let { key ->
+            if (!merged.has(key)) {
+                val directMatch = original.optJSONObject(key)
+                if (directMatch != null) {
+                    merged.put(key, directMatch)
+                } else {
+                    val iterator = original.keys()
+                    while (iterator.hasNext()) {
+                        val candidate = iterator.next()
+                        if (candidate.equals(key, ignoreCase = true)) {
+                            val secao = original.optJSONObject(candidate)
+                            if (secao != null) {
+                                merged.put(key, secao)
+                            }
+                            break
+                        }
+                    }
+                }
+            }
+        } ?: run {
+            val iterator = original.keys()
+            while (iterator.hasNext()) {
+                val key = iterator.next()
+                if (merged.has(key)) {
+                    continue
+                }
+                val secao = original.optJSONObject(key) ?: continue
+                if (secao.optJSONArray("itens") != null) {
+                    merged.put(key, secao)
+                }
+            }
+        }
+
+        return merged
     }
 
     private fun mostrarChecklist(checklist: JSONObject) {


### PR DESCRIPTION
## Summary
- merge embedded checklist payloads with legacy section data when required
- ensure the renderer always receives the section information needed to show stored answers
- prefill posto02 checklist form fields with the last submitted answers and montador selections

## Testing
- lint *(fails: Android SDK not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2d93ebee4832fb53e7f5172070efc