### PR TITLE
Set inspector title on action bar

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/InspetorActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/InspetorActivity.kt
@@ -17,6 +17,7 @@ class InspetorActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_inspetor)
+        supportActionBar?.title = getString(R.string.inspecao_title)
 
         // Botão de refresh
         val refreshButton: Button = findViewById(R.id.btnRefresh)

--- a/AppOficina/app/src/main/res/values/strings.xml
+++ b/AppOficina/app/src/main/res/values/strings.xml
@@ -6,4 +6,5 @@
     <string name="no_previous_checklist">Nenhum checklist anterior disponível</string>
     <string name="start_inspection">Iniciar inspeção</string>
     <string name="close">Fechar</string>
+    <string name="inspecao_title">INSPEÇÃO</string>
 </resources>


### PR DESCRIPTION
## Summary
- remove the extra layout heading so the inspector screen keeps its original structure
- set the inspector activity title to "INSPEÇÃO" via the action bar and add a dedicated string resource

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2ebb03edc832fa466858227dfd9fe