### PR TITLE
Show Posto 02 inspector history preview before inspection

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/Posto02InspetorFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/Posto02InspetorFragment.kt
@@ -89,16 +89,15 @@ class Posto02InspetorFragment : Fragment() {
                                             intent.putExtra("tipo", "insp_posto02")
                                             startActivity(intent)
                                         } else {
-                                            promptName(requireContext(), "Nome do inspetor") { nome ->
-                                                val intent = Intent(requireContext(), ChecklistPosto02InspActivity::class.java)
-                                                intent.putExtra("obra", obra)
-                                                intent.putExtra("ano", ano)
-                                                intent.putExtra("inspetor", nome)
-                                                checklistSnapshot?.let { snapshot ->
-                                                    intent.putExtra("initialChecklist", snapshot)
-                                                }
-                                                startActivity(intent)
+                                            val intent = Intent(requireContext(), ChecklistHistoryActivity::class.java)
+                                            intent.putExtra("obra", obra)
+                                            intent.putExtra("ano", ano)
+                                            intent.putExtra("tipo", "insp_posto02")
+                                            intent.putExtra("sectionKey", "posto02")
+                                            checklistSnapshot?.let { snapshot ->
+                                                intent.putExtra("initialChecklist", snapshot)
                                             }
+                                            startActivity(intent)
                                         }
                                     }
                                 }.start()


### PR DESCRIPTION
## Summary
- start ChecklistHistoryActivity when the inspector opens the Posto 02 checklist without divergences
- forward the last saved checklist snapshot so the preview displays the previous answers immediately

## Testing
- `./gradlew lint` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f0aef0bc832f9e1d0142441bf33b