### PR TITLE
Fix Posto 02 history preview population

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistHistoryActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistHistoryActivity.kt
@@ -28,6 +28,8 @@ class ChecklistHistoryActivity : AppCompatActivity() {
     private lateinit var startButton: Button
     private lateinit var closeButton: Button
 
+    private var lastChecklistSnapshot: String? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_checklist_history)
@@ -59,10 +61,13 @@ class ChecklistHistoryActivity : AppCompatActivity() {
 
         if (overrideChecklist != null) {
             mostrarEstadoCarregando()
-            val rendered = renderer.render(container, overrideChecklist)
+            val normalized = ChecklistPayloadUtils.resolveChecklist(sectionKey, overrideChecklist)
+            val rendered = renderer.render(container, normalized)
             if (rendered) {
+                lastChecklistSnapshot = normalized.toString()
                 mostrarConteudo()
             } else {
+                lastChecklistSnapshot = null
                 mostrarEstadoVazio()
             }
         } else {
@@ -114,8 +119,10 @@ class ChecklistHistoryActivity : AppCompatActivity() {
                     val checklist = ChecklistPayloadUtils.resolveChecklist(sectionKey, json)
                     runOnUiThread {
                         if (renderer.render(container, checklist)) {
+                            lastChecklistSnapshot = checklist.toString()
                             mostrarConteudo()
                         } else {
+                            lastChecklistSnapshot = null
                             mostrarEstadoVazio()
                         }
                     }
@@ -146,6 +153,7 @@ class ChecklistHistoryActivity : AppCompatActivity() {
     }
 
     private fun mostrarEstadoVazio() {
+        lastChecklistSnapshot = null
         runOnUiThread {
             loadingIndicator.visibility = View.GONE
             scrollView.visibility = View.GONE
@@ -170,6 +178,9 @@ class ChecklistHistoryActivity : AppCompatActivity() {
             intent.putExtra("obra", obra)
             intent.putExtra("ano", ano)
             intent.putExtra(extraName, nome)
+            lastChecklistSnapshot?.let { snapshot ->
+                intent.putExtra("initialChecklist", snapshot)
+            }
             startActivity(intent)
             finish()
         }

--- a/AppOficina/app/src/main/java/com/example/appoficina/Posto02InspetorFragment.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/Posto02InspetorFragment.kt
@@ -89,16 +89,15 @@ class Posto02InspetorFragment : Fragment() {
                                             intent.putExtra("tipo", "insp_posto02")
                                             startActivity(intent)
                                         } else {
-                                            promptName(requireContext(), "Nome do inspetor") { nome ->
-                                                val intent = Intent(requireContext(), ChecklistPosto02InspActivity::class.java)
-                                                intent.putExtra("obra", obra)
-                                                intent.putExtra("ano", ano)
-                                                intent.putExtra("inspetor", nome)
-                                                checklistSnapshot?.let { snapshot ->
-                                                    intent.putExtra("initialChecklist", snapshot)
-                                                }
-                                                startActivity(intent)
+                                            val intent = Intent(requireContext(), ChecklistHistoryActivity::class.java)
+                                            intent.putExtra("obra", obra)
+                                            intent.putExtra("ano", ano)
+                                            intent.putExtra("tipo", "insp_posto02")
+                                            intent.putExtra("sectionKey", "posto02")
+                                            checklistSnapshot?.let { snapshot ->
+                                                intent.putExtra("initialChecklist", snapshot)
                                             }
+                                            startActivity(intent)
                                         }
                                     }
                                 }.start()


### PR DESCRIPTION
## Summary
- normalize any provided checklist snapshot before rendering the history preview and only keep it when content is shown
- store the last rendered checklist payload to pass to the inspection activity so the floating preview opens with the latest answers

## Testing
- `./gradlew lint` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f0aef0bc832f9e1d0142441bf33b