### PR TITLE
Add inspector checklist retrieval endpoint

### DIFF
--- a/APP/site/json_api/__init__.py
+++ b/APP/site/json_api/__init__.py
@@ -862,6 +862,28 @@ def listar_posto02_insp_proj():
     return jsonify({'projetos': projetos})
 
 
+@bp.route('/posto02/insp/checklist', methods=['GET'])
+def obter_posto02_insp_checklist():
+    """Return checklist data stored in the inspector directory for ``obra``."""
+    obra = request.args.get('obra')
+    if not obra:
+        return jsonify({'erro': 'obra obrigatória'}), 400
+
+    file_path = os.path.join(
+        BASE_DIR,
+        'Posto02_Oficina',
+        'Posto02_Oficina_Inspetor',
+        f'checklist_{obra}.json',
+    )
+    if not os.path.exists(file_path):
+        return jsonify({'erro': 'arquivo não encontrado'}), 404
+
+    with open(file_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    return jsonify(data)
+
+
 @bp.route('/posto02/insp/upload', methods=['POST'])
 def posto02_insp_upload():
     """Process inspector answers and advance or return checklist."""

--- a/APP/tests/test_posto02_upload_inspection.py
+++ b/APP/tests/test_posto02_upload_inspection.py
@@ -60,3 +60,33 @@ def test_upload_and_inspection_without_divergencias(tmp_path):
     res_insp = client.post("/posto02/insp/upload", json=insp_payload)
     assert res_insp.status_code == 200
     assert res_insp.get_json()["divergencias"] == []
+
+
+def test_obter_posto02_insp_checklist_success(tmp_path):
+    insp_dir = tmp_path / "Posto02_Oficina" / "Posto02_Oficina_Inspetor"
+    insp_dir.mkdir(parents=True)
+    payload = {"obra": "OBRA2", "posto02": {"itens": [1, 2, 3]}}
+    with open(insp_dir / "checklist_OBRA2.json", "w", encoding="utf-8") as f:
+        json.dump(payload, f)
+
+    client = _client(tmp_path)
+
+    res = client.get("/posto02/insp/checklist", query_string={"obra": "OBRA2"})
+    assert res.status_code == 200
+    assert res.get_json() == payload
+
+
+def test_obter_posto02_insp_checklist_missing_param(tmp_path):
+    client = _client(tmp_path)
+
+    res = client.get("/posto02/insp/checklist")
+    assert res.status_code == 400
+    assert res.get_json()["erro"] == "obra obrigatória"
+
+
+def test_obter_posto02_insp_checklist_not_found(tmp_path):
+    client = _client(tmp_path)
+
+    res = client.get("/posto02/insp/checklist", query_string={"obra": "NAOEXISTE"})
+    assert res.status_code == 404
+    assert res.get_json()["erro"] == "arquivo não encontrado"


### PR DESCRIPTION
## Summary
- add inspector checklist retrieval endpoint mirroring posto02 logic
- read inspector checklist files by obra and return JSON payload or proper errors
- cover the new endpoint with tests for success, missing parameter, and missing file

## Testing
- pytest APP/tests

------
https://chatgpt.com/codex/tasks/task_e_68d2fe2b9338832f860c0b1f3ae887b0