### PR TITLE
feat: mostrar checklist do inspetor em janela flutuante

### DIFF
--- a/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02InspActivity.kt
+++ b/AppOficina/app/src/main/java/com/example/appoficina/ChecklistPosto02InspActivity.kt
@@ -2,7 +2,9 @@ package com.example.appoficina
 
 import android.content.Context
 import android.os.Bundle
+import android.view.MotionEvent
 import android.view.View
+import android.view.ViewGroup
 import android.widget.Button
 import android.widget.CheckBox
 import android.widget.ImageButton
@@ -20,11 +22,21 @@ import java.net.URL
 class ChecklistPosto02InspActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_checklist_posto02)
+        setContentView(R.layout.activity_checklist_posto02_insp)
 
         val obra = intent.getStringExtra("obra") ?: ""
         val ano = intent.getStringExtra("ano") ?: ""
         val inspetor = intent.getStringExtra("inspetor") ?: ""
+
+        val floatingContainer = findViewById<View>(R.id.checklist_window_container)
+        val floatingHeader = findViewById<View>(R.id.checklist_window_header)
+        val backdrop = findViewById<View>(R.id.floating_backdrop)
+        val closeButton = findViewById<ImageButton>(R.id.checklist_window_close_button)
+
+        enableFloatingDrag(floatingContainer, floatingHeader)
+
+        backdrop.setOnClickListener { finish() }
+        closeButton.setOnClickListener { finish() }
 
         val previewHelper = FloatingChecklistPreview(
             this,
@@ -172,6 +184,36 @@ class ChecklistPosto02InspActivity : AppCompatActivity() {
             Thread { enviarChecklist(payload, "/json_api/posto02/insp/upload") }.start()
             Toast.makeText(this, "Encaminhado ao próximo posto", Toast.LENGTH_SHORT).show()
             finish()
+        }
+    }
+
+    private fun enableFloatingDrag(target: View, handle: View) {
+        var offsetX = 0f
+        var offsetY = 0f
+
+        handle.setOnTouchListener { _, event ->
+            when (event.actionMasked) {
+                MotionEvent.ACTION_DOWN -> {
+                    offsetX = target.x - event.rawX
+                    offsetY = target.y - event.rawY
+                    true
+                }
+                MotionEvent.ACTION_MOVE -> {
+                    val parent = target.parent as? ViewGroup ?: return@setOnTouchListener false
+                    if (parent.width == 0 || parent.height == 0) {
+                        return@setOnTouchListener false
+                    }
+                    val maxX = (parent.width - target.width).coerceAtLeast(0)
+                    val maxY = (parent.height - target.height).coerceAtLeast(0)
+                    val newX = (event.rawX + offsetX).coerceIn(0f, maxX.toFloat())
+                    val newY = (event.rawY + offsetY).coerceIn(0f, maxY.toFloat())
+                    target.x = newX
+                    target.y = newY
+                    true
+                }
+                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> true
+                else -> false
+            }
         }
     }
 

--- a/AppOficina/app/src/main/res/layout/activity_checklist_posto02_insp.xml
+++ b/AppOficina/app/src/main/res/layout/activity_checklist_posto02_insp.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <View
+        android:id="@+id/floating_backdrop"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#66000000" />
+
+    <LinearLayout
+        android:id="@+id/checklist_window_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_margin="24dp"
+        android:background="@drawable/bg_preview_window"
+        android:elevation="12dp"
+        android:orientation="vertical"
+        android:paddingBottom="16dp">
+
+        <LinearLayout
+            android:id="@+id/checklist_window_header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:paddingStart="20dp"
+            android:paddingTop="16dp"
+            android:paddingEnd="8dp"
+            android:paddingBottom="12dp">
+
+            <TextView
+                android:id="@+id/checklist_window_title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/floating_checklist_title_posto02"
+                android:textAppearance="@style/TextAppearance.AppCompat.Title"
+                android:textStyle="bold" />
+
+            <ImageButton
+                android:id="@+id/checklist_window_close_button"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/close_checklist_window"
+                android:padding="8dp"
+                android:src="@android:drawable/ic_menu_close_clear_cancel"
+                android:tint="?android:attr/textColorPrimary" />
+        </LinearLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="#33000000" />
+
+        <ScrollView
+            android:id="@+id/checklist_scroll"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:fillViewport="true"
+            android:overScrollMode="ifContentScrolls">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <LinearLayout
+                    android:id="@+id/questions_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="end"
+                    android:orientation="horizontal"
+                    android:paddingTop="16dp">
+
+                    <Button
+                        android:id="@+id/btnConcluirPosto02"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/concluir" />
+
+                    <Button
+                        android:id="@+id/btnSeguirPosto02"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="12dp"
+                        android:text="@string/seguir" />
+                </LinearLayout>
+            </LinearLayout>
+        </ScrollView>
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/preview_container"
+        android:layout_width="300dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end|top"
+        android:layout_margin="16dp"
+        android:background="@drawable/bg_preview_window"
+        android:elevation="8dp"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <LinearLayout
+            android:id="@+id/preview_header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:padding="12dp">
+
+            <TextView
+                android:id="@+id/preview_title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/previous_checklist_title"
+                android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
+                android:textStyle="bold" />
+
+            <ImageButton
+                android:id="@+id/preview_close_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/close_previous_checklist"
+                android:padding="4dp"
+                android:src="@android:drawable/ic_menu_close_clear_cancel"
+                android:tint="?android:attr/textColorPrimary" />
+        </LinearLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="#33000000" />
+
+        <ScrollView
+            android:id="@+id/preview_scroll"
+            android:layout_width="match_parent"
+            android:layout_height="250dp"
+            android:fillViewport="true">
+
+            <LinearLayout
+                android:id="@+id/preview_content"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical" />
+        </ScrollView>
+    </LinearLayout>
+
+    <ImageButton
+        android:id="@+id/preview_toggle_button"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="end|bottom"
+        android:layout_margin="16dp"
+        android:background="@drawable/bg_preview_toggle"
+        android:contentDescription="@string/show_previous_checklist"
+        android:elevation="8dp"
+        android:padding="12dp"
+        android:src="@null"
+        android:visibility="gone" />
+
+</FrameLayout>

--- a/AppOficina/app/src/main/res/values/strings.xml
+++ b/AppOficina/app/src/main/res/values/strings.xml
@@ -7,4 +7,10 @@
     <string name="start_inspection">Iniciar inspeção</string>
     <string name="close">Fechar</string>
     <string name="inspecao_title">INSPEÇÃO</string>
+    <string name="floating_checklist_title_posto02">Checklist - Posto 02 (Inspetor)</string>
+    <string name="close_checklist_window">Fechar checklist</string>
+    <string name="previous_checklist_title">Pré-visualização do checklist anterior</string>
+    <string name="close_previous_checklist">Fechar pré-visualização</string>
+    <string name="concluir">Concluir</string>
+    <string name="seguir">Seguir</string>
 </resources>


### PR DESCRIPTION
## Summary
- criar layout específico do inspetor com checklist em janela flutuante e cabeçalho arrastável
- atualizar ChecklistPosto02InspActivity para usar o novo layout, habilitar arraste e fechar pelo fundo/ícone
- adicionar strings reutilizáveis para títulos, botões e descrições do novo modo

## Testing
- ./gradlew lint *(falha: ambiente sem Android SDK configurado)*

------
https://chatgpt.com/codex/tasks/task_e_68d2fdb8ffac832fb45987387ea9ea16