### PR TITLE
Flag NC/NA answers for checklist revision

### DIFF
--- a/APP/tests/test_merge_checklists.py
+++ b/APP/tests/test_merge_checklists.py
@@ -271,6 +271,29 @@ def test_find_mismatches_ignores_additional_production_annotations(tmp_path: pat
     assert find_mismatches(str(tmp_path)) == []
 
 
+def test_find_mismatches_reports_nc_answers(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "checklist_OBRA1.json"
+    _write_checklist(path, ["NC", "Carlos"], ["C", "Joao"])
+
+    resultado = find_mismatches(str(tmp_path))
+    assert len(resultado) == 1
+    divergencia = resultado[0]["divergencias"][0]
+    assert divergencia["suprimento"] == ["NC", "Carlos"]
+    assert divergencia["produção"] == ["C", "Joao"]
+    assert divergencia["respostas"]["suprimento"] == ["NC", "Carlos"]
+
+
+def test_find_mismatches_reports_na_answers(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "checklist_OBRA1.json"
+    _write_checklist(path, ["C", "Carlos"], ["NA", "Joao"])
+
+    resultado = find_mismatches(str(tmp_path))
+    assert len(resultado) == 1
+    divergencia = resultado[0]["divergencias"][0]
+    assert divergencia["suprimento"] == ["C", "Carlos"]
+    assert divergencia["produção"] == ["NA", "Joao"]
+
+
 def test_move_matching_preserves_extra_annotations(tmp_path: pathlib.Path) -> None:
     src_dir = tmp_path / "Posto01_Oficina"
     src_dir.mkdir()

--- a/AppEstoque/app/src/main/java/com/example/apestoque/adapter/DivergenciaAdapter.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/adapter/DivergenciaAdapter.kt
@@ -27,7 +27,9 @@ class DivergenciaAdapter(private val itens: List<Divergencia>) :
     override fun onBindViewHolder(holder: VH, position: Int) {
         val d = itens[position]
         holder.pergunta.text = "Item ${d.numero.joinToString()}: ${d.pergunta}"
-        holder.sup.text = "Suprimento: ${d.suprimento?.joinToString() ?: "-"}"
-        holder.prod.text = "Produção: ${d.producao?.joinToString() ?: "-"}"
+        val respostasSup = d.respostaSuprimento()
+        val respostasProd = d.respostaProducao()
+        holder.sup.text = "Suprimento: ${respostasSup?.joinToString() ?: "-"}"
+        holder.prod.text = "Produção: ${respostasProd?.joinToString() ?: "-"}"
     }
 }

--- a/AppEstoque/app/src/main/java/com/example/apestoque/data/Revisao.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/data/Revisao.kt
@@ -10,7 +10,38 @@ data class Divergencia(
     val pergunta: String,
     val suprimento: List<String>?,
     @Json(name = "produção") val producao: List<String>?,
-) : Serializable
+    @Json(name = "respostas") private val respostas: Map<String, List<String>>? = null,
+) : Serializable {
+    fun respostaSuprimento(): List<String>? {
+        val direta = suprimento
+        if (!direta.isNullOrEmpty()) {
+            return direta
+        }
+        return encontrarRespostas(listOf("suprimento"))
+    }
+
+    fun respostaProducao(): List<String>? {
+        val direta = producao
+        if (!direta.isNullOrEmpty()) {
+            return direta
+        }
+        return encontrarRespostas(listOf("produção", "producao", "montador", "inspetor"))
+    }
+
+    private fun encontrarRespostas(chaves: List<String>): List<String>? {
+        val mapa = respostas ?: return null
+        for (chave in chaves) {
+            mapa[chave]?.let { return it }
+        }
+        val normalizadas = chaves.map { it.lowercase() }.toSet()
+        for ((chave, valor) in mapa) {
+            if (chave.lowercase() in normalizadas) {
+                return valor
+            }
+        }
+        return null
+    }
+}
 
 @JsonClass(generateAdapter = true)
 data class RevisaoChecklist(


### PR DESCRIPTION
## Summary
- treat NC/NA checklist answers as divergences when consolidating checklists so obras return to revisão
- expose stored supply and production responses to the AppEstoque revisão UI so the non-conforming answer is visible

## Testing
- pytest APP/tests/test_merge_checklists.py
- ./gradlew assembleDebug *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d42233a698832fa8112c15e8756f0d