### PR TITLE
Handle production uploads without raw suprimento data

### DIFF
--- a/APP/site/json_api/merge_checklists.py
+++ b/APP/site/json_api/merge_checklists.py
@@ -386,6 +386,83 @@ def _dedup_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
 
 
+def _load_existing_suprimento_payload(
+    base_dir: str, obra: Any
+) -> Optional[Dict[str, Any]]:
+    """Return a synthetic suprimento payload based on previous merges.
+
+    When a production checklist arrives but the raw suprimento upload was
+    already consumed (and consequently deleted) we still need a baseline with
+    the warehouse answers in order to detect divergences. This helper inspects
+    the consolidated checklists stored under ``Posto01_Oficina`` and
+    ``Posto02_Oficina`` looking for a file that matches ``obra``. If found, the
+    function extracts only the suprimento answers and reshapes them into the
+    same structure produced by AppEstoque so that :func:`merge_checklists` can
+    operate normally.
+    """
+
+    if obra is None:
+        return None
+
+    obra_normalized = str(obra).strip()
+    if not obra_normalized:
+        return None
+
+    candidatos = ["Posto01_Oficina", "Posto02_Oficina"]
+    for folder in candidatos:
+        caminho = os.path.join(base_dir, folder, f"checklist_{obra_normalized}.json")
+        if not os.path.isfile(caminho):
+            continue
+        try:
+            with open(caminho, "r", encoding="utf-8") as fp:
+                dados = json.load(fp)
+        except Exception:
+            continue
+
+        itens_extraidos: List[Dict[str, Any]] = []
+        for item in dados.get("itens", []) or []:
+            respostas = item.get("respostas")
+            if not isinstance(respostas, dict):
+                continue
+            valores = respostas.get("suprimento")
+            if valores is None:
+                continue
+            if isinstance(valores, list):
+                lista = list(valores)
+            else:
+                lista = [valores]
+            if not lista:
+                continue
+            numero = item.get("numero")
+            if isinstance(numero, list):
+                numero_val = numero[0] if numero else None
+            else:
+                numero_val = numero
+            itens_extraidos.append(
+                {
+                    "numero": numero_val,
+                    "pergunta": item.get("pergunta"),
+                    "respostas": {"suprimento": lista},
+                }
+            )
+
+        if not itens_extraidos:
+            continue
+
+        respondentes = dados.get("respondentes", {}) or {}
+        suprimento_nome = respondentes.get("suprimento") or dados.get("suprimento")
+
+        return {
+            "obra": dados.get("obra", obra_normalized),
+            "ano": dados.get("ano", ""),
+            "suprimento": suprimento_nome,
+            "itens": itens_extraidos,
+            "materiais": dados.get("materiais", []),
+        }
+
+    return None
+
+
 def merge_directory(base_dir: str, output_dir: Optional[str] = None) -> List[Dict[str, Any]]:
     """Merge checklist pairs found in ``base_dir`` grouped by ``obra``.
 
@@ -437,6 +514,10 @@ def merge_directory(base_dir: str, output_dir: Optional[str] = None) -> List[Dic
             if sup_entries
             else None
         )
+        if sup is None:
+            fallback_sup = _load_existing_suprimento_payload(base_dir, obra)
+            if fallback_sup is not None:
+                sup = {"data": fallback_sup, "path": None}
         prod = (
             max(prod_entries, key=lambda e: os.path.getmtime(e["path"]))
             if prod_entries
@@ -445,17 +526,25 @@ def merge_directory(base_dir: str, output_dir: Optional[str] = None) -> List[Dic
 
         # remove older checklist files to avoid leftovers
         for entry in sup_entries:
-            if sup is None or entry["path"] != sup["path"]:
-                try:
-                    os.remove(entry["path"])
-                except OSError:
-                    pass
+            if sup is None:
+                continue
+            caminho = entry.get("path")
+            if not caminho or caminho == sup.get("path"):
+                continue
+            try:
+                os.remove(caminho)
+            except OSError:
+                pass
         for entry in prod_entries:
-            if prod is None or entry["path"] != prod["path"]:
-                try:
-                    os.remove(entry["path"])
-                except OSError:
-                    pass
+            if prod is None:
+                continue
+            caminho = entry.get("path")
+            if not caminho or caminho == prod.get("path"):
+                continue
+            try:
+                os.remove(caminho)
+            except OSError:
+                pass
 
         if not (sup and prod):
             continue
@@ -488,11 +577,16 @@ def merge_directory(base_dir: str, output_dir: Optional[str] = None) -> List[Dic
 
         with open(out_path, "w", encoding="utf-8") as fp:
             json.dump(result, fp, ensure_ascii=False, indent=2)
-        try:
-            os.remove(sup["path"])
-            os.remove(prod["path"])
-        except OSError:
-            pass
+        for chosen in (sup, prod):
+            if not chosen:
+                continue
+            caminho = chosen.get("path")
+            if not caminho:
+                continue
+            try:
+                os.remove(caminho)
+            except OSError:
+                pass
         merged.append(result)
     return merged
 

--- a/APP/tests/test_merge_checklists.py
+++ b/APP/tests/test_merge_checklists.py
@@ -264,6 +264,61 @@ def test_merge_directory_preserves_suprimento_answers_for_component_block(
         assert respostas["producao"][0] == "C"
 
 
+def test_merge_directory_reuses_previous_suprimento_answers(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Production uploads should reuse the last known suprimento answers."""
+
+    posto02 = tmp_path / "Posto02_Oficina"
+    posto02.mkdir()
+
+    merged_payload = {
+        "obra": "OBRA1",
+        "ano": "2024",
+        "respondentes": {"suprimento": "Victor", "produção": "Carlos"},
+        "itens": [
+            {
+                "numero": [1],
+                "pergunta": "Pergunta",
+                "respostas": {
+                    "suprimento": ["C", "Victor"],
+                    "producao": ["C", "Carlos"],
+                },
+            }
+        ],
+        "materiais": [],
+    }
+    (posto02 / "checklist_OBRA1.json").write_text(
+        json.dumps(merged_payload), encoding="utf-8"
+    )
+
+    novo_prod = {
+        "obra": "OBRA1",
+        "ano": "2024",
+        "origem": "AppOficina",
+        "itens": [
+            {
+                "numero": 1,
+                "pergunta": "Pergunta",
+                "respostas": {"producao": ["NC", "Carlos"]},
+            }
+        ],
+    }
+    raw_path = tmp_path / "checklist_OBRA1_20240101.json"
+    raw_path.write_text(json.dumps(novo_prod), encoding="utf-8")
+
+    merged = merge.merge_directory(str(tmp_path))
+
+    assert merged, "Expected merge to reuse suprimento payload"
+    respostas = merged[0]["itens"][0]["respostas"]
+    assert respostas["suprimento"][0] == "C"
+    assert respostas["producao"][0] == "NC"
+
+    destino = tmp_path / "Posto01_Oficina" / "checklist_OBRA1.json"
+    assert destino.exists(), "Merged checklist should be stored for revisão"
+    assert not raw_path.exists(), "Raw production upload must be removed"
+
+
 def test_find_mismatches_ignores_additional_production_annotations(tmp_path: pathlib.Path) -> None:
     path = tmp_path / "checklist_OBRA1.json"
     _write_checklist(path, ["C", "Joao"], ["C", "Joao", "Maria"])


### PR DESCRIPTION
## Summary
- reuse previously merged checklists as a suprimento baseline when new AppOficina uploads arrive without raw warehouse data
- guard cleanup logic so we do not attempt to delete non-existent fallback files
- add a regression test covering the fallback merge behaviour

## Testing
- pytest tests/test_merge_checklists.py

------
https://chatgpt.com/codex/tasks/task_e_68d42c927db0832f8e77dfbcbc186a84