### PR TITLE
Ajusta filtro de solicitações na aba de Compras

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/fragments/ComprasFragment.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/fragments/ComprasFragment.kt
@@ -47,7 +47,10 @@ class ComprasFragment : Fragment() {
         lifecycleScope.launch {
             try {
                 val lista = withContext(Dispatchers.IO) { NetworkModule.api(requireContext()).listarSolicitacoes() }
-                val pendentes = lista.filter { it.status != "aprovado" }
+                val statusCompras = setOf("compras", "pendente_compras")
+                val pendentes = lista.filter { sol ->
+                    sol.status?.lowercase() in statusCompras
+                }
                 if (pendentes.isEmpty()) {
                     tvMsg.text = "Nenhuma solicitação."
                     tvMsg.visibility = View.VISIBLE


### PR DESCRIPTION
## Summary
- restringe a lista de solicitações exibidas na aba Compras apenas a status voltados ao time de compras

## Testing
- `./gradlew test` *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d441c96064832fa36a5562f80bc2d5