### PR TITLE
Atualiza status inicial dos itens para "Separado"

### DIFF
--- a/APP/site/app.py
+++ b/APP/site/app.py
@@ -87,7 +87,13 @@ def create_app():
             cols = [c['name'] for c in insp.get_columns('item')]
             if 'status' not in cols:
                 db.session.execute(
-                    text("ALTER TABLE item ADD COLUMN status VARCHAR(20) DEFAULT 'Nao iniciada'")
+                    text("ALTER TABLE item ADD COLUMN status VARCHAR(20) DEFAULT 'Separado'")
+                )
+                db.session.commit()
+            else:
+                # atualiza registros legados para refletirem o novo status inicial
+                db.session.execute(
+                    text("UPDATE item SET status = 'Separado' WHERE status = 'Nao iniciada'")
                 )
                 db.session.commit()
             if 'previsao_entrega' not in cols:

--- a/APP/site/models.py
+++ b/APP/site/models.py
@@ -8,7 +8,7 @@ db = SQLAlchemy()
 
 # Opções de status individuais para cada item
 ITEM_STATUS_OPTIONS = [
-    'Nao iniciada',
+    'Separado',
     'Em cotação',
     'Fechado',
     'Faturado',
@@ -34,7 +34,7 @@ class Item(db.Model):
     solicitacao_id = db.Column(db.Integer, db.ForeignKey('solicitacao.id'), nullable=False)
     referencia = db.Column(db.String(100), nullable=False)
     quantidade = db.Column(db.Integer, nullable=False)
-    status = db.Column(db.String(20), default='Nao iniciada')
+    status = db.Column(db.String(20), default='Separado')
     previsao_entrega = db.Column(db.Date)
 
 

--- a/APP/site/projetista/__init__.py
+++ b/APP/site/projetista/__init__.py
@@ -265,7 +265,7 @@ def nova_solicitacao():
                     solicitacao_id=sol.id,
                     referencia=str(ref).strip(),
                     quantidade=int(qt),
-                    status='Nao iniciada'
+                    status='Separado'
                 )
                 db.session.add(item)
 
@@ -281,7 +281,7 @@ def nova_solicitacao():
                     solicitacao_id=sol.id,
                     referencia=ref,
                     quantidade=int(qt),
-                    status='Nao iniciada'
+                    status='Separado'
                 )
                 db.session.add(item)
 


### PR DESCRIPTION
## Summary
- define "Separado" como novo status inicial dos itens criados em solicitações do projetista
- atualiza a configuração do banco para refletir o novo status e corrigir registros legados

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc2d390700832f9d72f7c52aa8ee5c