### PR TITLE
Use custom alarm sound for inspection notifications

### DIFF
--- a/AppEstoque/app/src/main/java/com/example/apestoque/util/InspecaoPollingWorker.kt
+++ b/AppEstoque/app/src/main/java/com/example/apestoque/util/InspecaoPollingWorker.kt
@@ -7,9 +7,9 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.media.AudioAttributes
-import android.media.RingtoneManager
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
@@ -21,6 +21,7 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import com.example.apestoque.BuildConfig
 import com.example.apestoque.MainActivity
 import com.example.apestoque.R
 import com.example.apestoque.data.NetworkModule
@@ -109,7 +110,7 @@ class InspecaoPollingWorker(
             )
         }
 
-        val alarmSound = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)
+        val alarmSound = customAlarmSound()
         val audioAttributes = AudioAttributes.Builder()
             .setUsage(AudioAttributes.USAGE_ALARM)
             .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
@@ -139,7 +140,7 @@ class InspecaoPollingWorker(
 
     private fun ensureChannel() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val alarmSound = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)
+            val alarmSound = customAlarmSound()
             val audioAttributes = AudioAttributes.Builder()
                 .setUsage(AudioAttributes.USAGE_ALARM)
                 .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
@@ -176,6 +177,9 @@ class InspecaoPollingWorker(
         private const val NOTIFICATION_ID = 1001
         private const val ALERT_INTERVAL_SECONDS = 30L
         private val VIBRATION_PATTERN = longArrayOf(0, 800, 400, 800, 400, 800, 400, 800)
+
+        private fun customAlarmSound(): Uri =
+            Uri.parse("android.resource://" + BuildConfig.APPLICATION_ID + "/" + R.raw.meualarme)
 
         fun schedule(context: Context) {
             scheduleNext(context, 0)


### PR DESCRIPTION
## Summary
- play the inspection polling notification with the bundled meualarme.mp3 tone
- ensure the notification channel reuses the same custom audio resource when (re)created

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc415d6b1c832fbde20a1d808a1fe5